### PR TITLE
Add missing python version to script style check

### DIFF
--- a/.github/workflows/pep8_nb_style_check.yml
+++ b/.github/workflows/pep8_nb_style_check.yml
@@ -12,3 +12,5 @@ on:
 jobs:
   Notebook_PEP8_Check:
    uses: spacetelescope/notebook-ci-actions/.github/workflows/notebook_pep8check.yml@v3
+   with:
+     python-version: ${{ vars.PYTHON_VERSION }}


### PR DESCRIPTION
This PR is to fix: Invalid workflow file: .github/workflows/pep8_nb_style_check.yml#L14
The workflow is not valid. .github/workflows/pep8_nb_style_check.yml (Line: 14, Col: 10): Input python-version is required, but not provided while calling.
