### PR TITLE
FInal version of NIRISS Imaging with new name

### DIFF
--- a/notebooks/NIRISS/JWpipeNB-niriss-imaging.ipynb
+++ b/notebooks/NIRISS/JWpipeNB-niriss-imaging.ipynb
@@ -1,0 +1,1371 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "095a295c",
+   "metadata": {},
+   "source": [
+    "<img style=\"float: center;\" src='https://github.com/spacetelescope/jwst-pipeline-notebooks/raw/main/_static/stsci_header.png' alt=\"stsci_logo\" width=\"900px\"/> "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0393e357-9d9d-4516-b28d-4d335fad33a0",
+   "metadata": {},
+   "source": [
+    "#  NIRISS Imaging Pipeline Notebook\n",
+    "\n",
+    "**Authors**: xxx<br>\n",
+    "**Last Updated**: January 24, 2024<br>\n",
+    "**Pipeline Version**: 1.14.1 (Build 10.2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7da2029f",
+   "metadata": {},
+   "source": [
+    "**Purpose**:\n",
+    "\n",
+    "This notebook provides a framework for processing generic Near-Infrared\n",
+    "Imager and Slitless Spectrograph (NIRISS) Imaging data through all\n",
+    "three James Webb Space Telescope (JWST) pipeline stages.  Data is assumed\n",
+    "to be located in one observation folder according to paths set up below.\n",
+    "It should not be necessary to edit any cells other than in the \n",
+    "[Configuration](#1.-Configuration) section unless modifying the standard \n",
+    "pipeline processing options.\n",
+    "\n",
+    "**Data**:\n",
+    "This example is set up to use an example dataset is from\n",
+    "[Program ID](https://www.stsci.edu/jwst/science-execution/program-information)\n",
+    "1475 (PI: Boyer, CoI: Volk) which is a sky flat calibration program. \n",
+    "NIRCam is used as the primary instrument with NIRISS as a \n",
+    "[coordinated parallel instrument](https://jwst-docs.stsci.edu/methods-and-roadmaps/jwst-parallel-observations/jwst-coordinated-parallels-roadmap).\n",
+    "The NIRISS imaging dataset uses a 17-step dither pattern.\n",
+    "\n",
+    "Example input data to use will be downloaded automatically unless\n",
+    "disabled (i.e., to use local files instead).\n",
+    "\n",
+    "**JWST pipeline version and CRDS context** This notebook was written for the\n",
+    "calibration pipeline version given above. It sets the CRDS context\n",
+    "to use the most recent version available in the JWST Calibration\n",
+    "Reference Data System (CRDS). If you use different pipeline versions or\n",
+    "CRDS context, please read the relevant release notes\n",
+    "([here for pipeline](https://github.com/spacetelescope/jwst),\n",
+    "[here for CRDS](https://jwst-crds.stsci.edu/)) for possibly relevant\n",
+    "changes.<BR>\n",
+    "\n",
+    "**Updates**:\n",
+    "This notebook is regularly updated as improvements are made to the\n",
+    "pipeline. Find the most up to date version of this notebook at:\n",
+    "https://github.com/spacetelescope/jwst-pipeline-notebooks/\n",
+    "\n",
+    "**Recent Changes**:<br>\n",
+    "January 24, 2024: original notebook released??????????\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5291c2f1",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Table of Contents\n",
+    "1. [Configuration](#1.-Configuration) \n",
+    "2. [Package Imports](#2.-Package-Imports)\n",
+    "3. [Demo Mode Setup (ignore if not using demo data)](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data))\n",
+    "4. [Directory Setup](#4.-Directory-Setup)\n",
+    "3. [Detector 1 Pipelineg](#5.-Detector1-Pipeline)\n",
+    "4. [Image2 Pipeline](#6.-Image2-Pipeline)\n",
+    "5. [Image3 Pipeline](#7.-Image3-Pipeline)\n",
+    "6. [Visualize the data](#8.-Visualize-the-data)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43bd07d7",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration\n",
+    "------------------\n",
+    "Set basic configuration for runing notebook. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "026a649d-a0d2-4e3f-ab6d-cf8c26e6ce1d",
+   "metadata": {},
+   "source": [
+    "#### Install dependencies and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe5c4ca9",
+   "metadata": {},
+   "source": [
+    "To make sure that the pipeline version is compatabile with the steps\n",
+    "discussed below and the required dependencies and packages are installed,\n",
+    " you can create a fresh conda environment and install the provided\n",
+    "`requirements.txt` file:\n",
+    "```\n",
+    "conda create -n niriss_imaging_pipeline python=3.11\n",
+    "conda activate niriss_imaging_pipeline\n",
+    "pip install -r requirements.txt\n",
+    "```\n",
+    "\n",
+    "Set the basic parameters to use with this notebook. These will affect\n",
+    "what data is used, where data is located (if already in disk), and\n",
+    "pipeline modules run in this data. The list of parameters are:\n",
+    "\n",
+    "* demo_mode\n",
+    "* directories with data\n",
+    "* pipeline modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06ea414c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic import necessary for configuration\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61bb14e6",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Note that <code>demo_mode</code> must be set appropriately below.\n",
+    "</div>\n",
+    "\n",
+    "Set <code>demo_mode = True </code> to run in demonstration mode. In this\n",
+    "mode this notebook will download example data from the Barbara A.\n",
+    "Mikulski Archive for Space Telescopes (MAST) and process it through the\n",
+    "pipeline. This will all happen in a local directory unless modified\n",
+    "in [Section 3](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data))\n",
+    "below. \n",
+    "\n",
+    "Set <code>demo_mode = False</code> if you want to process your own data\n",
+    "that has already been downloaded and provide the location of the data.<br>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "323f87d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set parameters for demo_mode, channel, band, data mode directories, and \n",
+    "# processing steps.\n",
+    "\n",
+    "# -----------------------------Demo Mode---------------------------------\n",
+    "demo_mode = True\n",
+    "\n",
+    "if demo_mode:\n",
+    "    print('Running in demonstration mode using online example data!')\n",
+    "\n",
+    "# --------------------------User Mode Directories------------------------\n",
+    "# If demo_mode = False, look for user data in these paths\n",
+    "if not demo_mode:\n",
+    "    # Set directory paths for processing specific data; these will need\n",
+    "    # to be changed to your local directory setup (below are given as\n",
+    "    # examples)\n",
+    "    user_home_dir = os.path.expanduser('~')\n",
+    "\n",
+    "    # Point to where science observation data are\n",
+    "    # Assumes uncalibrated data in sci_dir/uncal/ and results in stage1,\n",
+    "    # stage2, stage3 directories\n",
+    "    sci_dir = os.path.join(user_home_dir, 'FlightData/APT1475/data/Obs006/')\n",
+    "\n",
+    "# --------------------------Set Processing Steps--------------------------\n",
+    "# Individual pipeline stages can be turned on/off here.  Note that a later\n",
+    "# stage won't be able to run unless data products have already been\n",
+    "# produced from the prior stage.\n",
+    "\n",
+    "# Science processing\n",
+    "dodet1 = True  # calwebb_detector1\n",
+    "doimage2 = True  # calwebb_image2\n",
+    "doimage3 = True  # calwebb_image3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1070079a",
+   "metadata": {},
+   "source": [
+    "### Set CRDS context and server\n",
+    "Before importing <code>CRDS</code> and <code>JWST</code> modules, we need\n",
+    "to configure our environment. This includes defining a CRDS cache\n",
+    "directory in which to keep the reference files that will be used by the\n",
+    "calibration pipeline.\n",
+    "\n",
+    "If the root directory for the local CRDS cache directory has not been set\n",
+    "already, it will be set to create one in the home directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "baf7070d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ------------------------Set CRDS context and paths----------------------\n",
+    "\n",
+    "# Set CRDS context (if overriding to use a specific version of reference\n",
+    "# files; leave commented out to use latest reference files by default)\n",
+    "#%env CRDS_CONTEXT  jwst_1254.pmap\n",
+    "\n",
+    "# Check whether the local CRDS cache directory has been set.\n",
+    "# If not, set it to the user home directory\n",
+    "if (os.getenv('CRDS_PATH') is None):\n",
+    "    os.environ['CRDS_PATH'] = os.path.join(os.path.expanduser('~'), 'crds')\n",
+    "# Check whether the CRDS server URL has been set.  If not, set it.\n",
+    "if (os.getenv('CRDS_SERVER_URL') is None):\n",
+    "    os.environ['CRDS_SERVER_URL'] = 'https://jwst-crds.stsci.edu'\n",
+    "\n",
+    "# Echo CRDS path in use\n",
+    "print(f\"CRDS local filepath: {os.environ['CRDS_PATH']}\")\n",
+    "print(f\"CRDS file server: {os.environ['CRDS_SERVER_URL']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "575588c8",
+   "metadata": {},
+   "source": [
+    "## 2. Package Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4415f6d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the entire available screen width for this notebook\n",
+    "from IPython.display import display, HTML\n",
+    "display(HTML(\"<style>.container { width:95% !important; }</style>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb9f7f54-ff98-428b-9fa9-b39c50210c3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic system utilities for interacting with files\n",
+    "# ----------------------General Imports------------------------------------\n",
+    "import glob\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "#import urllib.request\n",
+    "\n",
+    "# Numpy for doing calculations\n",
+    "import numpy as np\n",
+    "\n",
+    "# -----------------------Astroquery Imports--------------------------------\n",
+    "# ASCII files, and downloading demo files\n",
+    "from astroquery.mast import Observations\n",
+    "\n",
+    "# For visualizing images\n",
+    "from jdaviz import Imviz\n",
+    "\n",
+    "# Astropy routines for visualizing detected sources:\n",
+    "from astropy.table import Table\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "\n",
+    "# for JWST calibration pipeline\n",
+    "import jwst\n",
+    "import crds\n",
+    "\n",
+    "from jwst.pipeline import Detector1Pipeline\n",
+    "from jwst.pipeline import Image2Pipeline\n",
+    "from jwst.pipeline import Image3Pipeline\n",
+    "\n",
+    "# JWST pipeline utilities\n",
+    "from jwst import datamodels\n",
+    "from jwst.associations import asn_from_list  # Tools for creating association files\n",
+    "from jwst.associations.lib.rules_level3_base import DMS_Level3_Base  # Definition of a Lvl3 association file\n",
+    "\n",
+    "# Echo pipeline version and CRDS context in use\n",
+    "print(f\"JWST Calibration Pipeline Version: {jwst.__version__}\")\n",
+    "print(f\"Using CRDS Context: {crds.get_context_name('jwst')}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5844d476-f8b3-4c24-9c79-091d6016314d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start a timer to keep track of runtime\n",
+    "time0 = time.perf_counter()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ef8050f",
+   "metadata": {},
+   "source": [
+    "## 3. Demo Mode Setup (ignore if not using demo data)\n",
+    "------------------\n",
+    "If running in demonstration mode, set up the program information to\n",
+    "retrieve the uncalibrated data automatically from MAST using\n",
+    "[astroquery](https://astroquery.readthedocs.io/en/latest/mast/mast.html).\n",
+    "MAST allows for flexibility of searching by the proposal ID and the\n",
+    "observation ID instead of just filenames.<br>\n",
+    "\n",
+    "For illustrative purposes, we focus on data taken through the NIRISS\n",
+    "[F150W filter](https://jwst-docs.stsci.edu/jwst-near-infrared-imager-and-slitless-spectrograph/niriss-instrumentation/niriss-filters)\n",
+    "and start with uncalibrated data products. The files are named\n",
+    "`jw01475006001_02201_000nn_nis_uncal.fits`, where *nn* refers to the\n",
+    " dither step number which ranges from 01 - 17. \n",
+    " \n",
+    "More information about the JWST file naming conventions can be found at:\n",
+    "https://jwst-pipeline.readthedocs.io/en/latest/jwst/data_products/file_naming.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d595f1e-2590-4f01-bb92-13bb43a22b3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up the program information and paths for demo program\n",
+    "if demo_mode:\n",
+    "    print('Running in demonstration mode and will download example data from MAST!')\n",
+    "    program = '01475'\n",
+    "    sci_observtn = \"006\"\n",
+    "    visit = \"001\"\n",
+    "    data_dir = os.path.join('.', 'nis_im_demo_data')\n",
+    "    download_dir = data_dir\n",
+    "    sci_dir = os.path.join(data_dir, 'Obs' + sci_observtn)\n",
+    "    uncal_dir = os.path.join(sci_dir, 'uncal')\n",
+    "\n",
+    "    # Ensure filepaths for input data exist\n",
+    "    if not os.path.exists(uncal_dir):\n",
+    "        os.makedirs(uncal_dir)\n",
+    "        \n",
+    "    # Create directory if it does not exist\n",
+    "    if not os.path.isdir(data_dir):\n",
+    "        os.mkdir(data_dir)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6674a8b8",
+   "metadata": {},
+   "source": [
+    "Identify list of science (SCI) uncalibrated files associated with visits.\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Selects only filter <i>f150w</i> data \n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4b22375",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Obtain a list of observation IDs for the specified demo program\n",
+    "if demo_mode:\n",
+    "    # Science data\n",
+    "    sci_obs_id_table = Observations.query_criteria(instrument_name=[\"NIRISS/IMAGE\"],\n",
+    "                                                   provenance_name=[\"CALJWST\"],  # Executed observations\n",
+    "                                                   filters=['F150W'],  # Data for Specific Filter\n",
+    "                                                   obs_id=['jw' + program + '-o' + sci_observtn + '*']\n",
+    "                                                   )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a666350e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Turn the list of visits into a list of uncalibrated data files\n",
+    "if demo_mode:\n",
+    "    # Define types of files to select\n",
+    "    file_dict = {'uncal': {'product_type': 'SCIENCE',\n",
+    "                           'productSubGroupDescription': 'UNCAL',\n",
+    "                           'calib_level': [1]}}\n",
+    "\n",
+    "    # Science files\n",
+    "    sci_files_to_download = []\n",
+    "    # Loop over visits identifying uncalibrated files that are associated\n",
+    "    # with them\n",
+    "    for exposure in (sci_obs_id_table):\n",
+    "        products = Observations.get_product_list(exposure)\n",
+    "        for filetype, query_dict in file_dict.items():\n",
+    "            filtered_products = Observations.filter_products(products, productType=query_dict['product_type'],\n",
+    "                                                             productSubGroupDescription=query_dict['productSubGroupDescription'],\n",
+    "                                                             calib_level=query_dict['calib_level'])\n",
+    "            sci_files_to_download.extend(filtered_products['dataURI'])\n",
+    " \n",
+    "    sci_files_to_download = sorted(sci_files_to_download)\n",
+    "    print(f\"Science files selected for downloading: {len(sci_files_to_download)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c36a54be",
+   "metadata": {},
+   "source": [
+    "Download all the uncal files and place them into the appropriate\n",
+    "directories.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Warning: If this notebook is halted during this step the downloaded file\n",
+    "may be incomplete, and cause crashes later on!\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "764fa682",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if demo_mode:\n",
+    "    for filename in sci_files_to_download:\n",
+    "        sci_manifest = Observations.download_file(filename,\n",
+    "                                                  local_path=os.path.join(uncal_dir, Path(filename).name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6c51254-6295-4f98-bc25-d07300e0d8f4",
+   "metadata": {},
+   "source": [
+    "## 4. Directory Setup\n",
+    "------------------\n",
+    "Set up detailed paths to input/output stages here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bffbedc3-fbe3-4c56-ad18-85b5d0c7d880",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define output subdirectories to keep science data products organized\n",
+    "uncal_dir = os.path.join(sci_dir, 'uncal')  # Uncalibrated pipeline inputs should be here\n",
+    "det1_dir = os.path.join(sci_dir, 'stage1')  # calwebb_detector1 pipeline outputs will go here\n",
+    "image2_dir = os.path.join(sci_dir, 'stage2')  # calwebb_spec2 pipeline outputs will go here\n",
+    "image3_dir = os.path.join(sci_dir, 'stage3')  # calwebb_spec3 pipeline outputs will go here\n",
+    "\n",
+    "# We need to check that the desired output directories exist, and if not\n",
+    "# create them\n",
+    "if not os.path.exists(det1_dir):\n",
+    "    os.makedirs(det1_dir)\n",
+    "if not os.path.exists(image2_dir):\n",
+    "    os.makedirs(image2_dir)\n",
+    "if not os.path.exists(image3_dir):\n",
+    "    os.makedirs(image3_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cd8e6a7-433d-4e5b-a832-46f0bc96a0fe",
+   "metadata": {},
+   "source": [
+    "Look at the first file to determine exposure parameters and practice using\n",
+    "JWST datamodels¶"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f767a7fa-50cb-4411-8aef-a32b7fde8917",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uncal_files = sorted(glob.glob(os.path.join(uncal_dir, '*_uncal.fits')))\n",
+    "\n",
+    "# print file name\n",
+    "print(uncal_files[0])\n",
+    "\n",
+    "# Open file as JWST datamodel\n",
+    "examine = datamodels.open(uncal_files[0])\n",
+    "\n",
+    "# Print out exposure info\n",
+    "print(f\"Instrument: {examine.meta.instrument.name}\")\n",
+    "print(f\"Filter: {examine.meta.instrument.filter}\")\n",
+    "print(f\"Pupil: {examine.meta.instrument.pupil}\")\n",
+    "print(f\"Number of integrations: {examine.meta.exposure.nints}\")\n",
+    "print(f\"Number of groups: {examine.meta.exposure.ngroups}\")\n",
+    "print(f\"Readout pattern: {examine.meta.exposure.readpatt}\")\n",
+    "print(f\"Dither position number: {examine.meta.dither.position_number}\")\n",
+    "print(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0469a648-9bb1-40f9-9f8b-fb3a29bc5c7f",
+   "metadata": {},
+   "source": [
+    "From the above, we confirm that the data file is for the NIRISS instrument\n",
+    "using the `F150W` filter in the [Pupil Wheel](https://jwst-docs.stsci.edu/jwst-near-infrared-imager-and-slitless-spectrograph/niriss-instrumentation/niriss-pupil-and-filter-wheels)\n",
+    "crossed with the `CLEAR` filter in the Filter Wheel. This observation uses\n",
+    "the [`NIS` readout pattern](https://jwst-docs.stsci.edu/jwst-near-infrared-imager-and-slitless-spectrograph/niriss-instrumentation/niriss-detector-overview/niriss-detector-readout-patterns),\n",
+    "16 groups per integration, and 1 integration per exposure. This data file\n",
+    "is the 1st dither position in this exposure sequence. For more information\n",
+    "about how JWST exposures are defined by up-the-ramp sampling, see the\n",
+    "[Understanding Exposure Times JDox article](https://jwst-docs.stsci.edu/understanding-exposure-times).\n",
+    "\n",
+    "This metadata will be the same for all exposures in this observation other\n",
+    "than the dither position number."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f843ff7f-58b6-4294-bfaa-606c29abc524",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time1 - time0:0.4f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "267e28e0-a63f-4790-b8a0-3ad4bff5a167",
+   "metadata": {},
+   "source": [
+    "## 5. Detector1 Pipeline\n",
+    "Run the datasets through the\n",
+    "[Detector1](https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline-overview/stages-of-jwst-data-processing/calwebb_detector1)\n",
+    "stage of the pipelineto apply detector level calibrations and create a\n",
+    "countrate data product where slopes are fitted to the integration ramps.\n",
+    "These `*_rate.fits` products are 2D (nrows x ncols), averaged over all\n",
+    "integrations. 3D countrate data products (`*_rateints.fits`) are also\n",
+    "created (nintegrations x nrows x ncols) which have the fitted ramp slopes\n",
+    "for each integration.\n",
+    "\n",
+    "By default, all steps in the Detector1 stage of the pipeline are run for\n",
+    "NIRISS except: the `ipc` correction step and the `gain_scale` step. Note\n",
+    "that while the [`persistence` step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/persistence/description.html)\n",
+    "is set to run by default, this step does not automatically correct the\n",
+    "science data for persistence. The `persistence` step creates a\n",
+    "`*_trapsfilled.fits` file which is a model that records the number\n",
+    "of traps filled at each pixel at the end of an exposure. This file would be \n",
+    "used as an input to the `persistence` step, via the `input_trapsfilled`\n",
+    "argument, to correct a science exposure for persistence. Since persistence\n",
+    "is not well calibrated for NIRISS, we do not perform a persistence\n",
+    "correction and thus turn off this step to speed up calibration and to not\n",
+    "create files that will not be used in the subsequent analysis. This step\n",
+    "can be turned off when running the pipeline in Python by doing:\n",
+    "```\n",
+    "rate_result = Detector1Pipeline.call(uncal,steps={'persistence': {'skip': True}})\n",
+    "```\n",
+    "or as indicated in the cell bellow using a dictionary.\n",
+    "\n",
+    "The [charge_migration step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/charge_migration/index.html#charge-migration-step)\n",
+    "is particularly important for NIRISS images to mitigate apparent flux loss\n",
+    "in resampled images due to the spilling of charge from a central pixel into\n",
+    "its neighboring pixels (see [Goudfrooij et al. 2023](https://ui.adsabs.harvard.edu/abs/2023arXiv231116301G/abstract)\n",
+    "for details). Charge migration occurs when the accumulated charge in a\n",
+    "central pixel exceeds a certain signal limit, which is ~25,000 ADU. This\n",
+    "step is turned on by default for NIRISS imaging mode when using CRDS\n",
+    "contexts of `jwst_1159.pmap` or later. Different signal limits for each filter are provided by the \n",
+    "[pars-chargemigrationstep parameter files](https://jwst-crds.stsci.edu). \n",
+    "Users can specify a different signal limit by running this step with the\n",
+    "`signal_threshold` flag and entering another signal limit in units of ADU.\n",
+    "\n",
+    "As of CRDS context `jwst_1155.pmap` and later, the \n",
+    "[`jump` step](https://jwst-pipeline.readthedocs.io/en/latest/api/jwst.jump.JumpStep.html)\n",
+    "of the `DETECTOR1` stage of the pipeline will remove residuals associated\n",
+    " with [snowballs](https://jwst-docs.stsci.edu/known-issues-with-jwst-data/shower-and-snowball-artifacts)\n",
+    " for the NIRISS imaging mode. The default parameters for this correction,\n",
+    " where `expand_large_events` set to `True` turns on the snowball halo\n",
+    " removal algorithm, are specified in the `pars-jumpstep` parameter\n",
+    " reference files. Users may wish to alter parameters to optimize removal of\n",
+    " snowball residuals. Available parameters are discussed in the\n",
+    " [Detection and Flagging of Showers and Snowballs in JWST Technical Report (Regan 2023)](https://www.stsci.edu/files/live/sites/www/files/home/jwst/documentation/technical-documents/_documents/JWST-STScI-008545.pdf)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3592ee58-b424-4bd6-973b-88fd081b81d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a dictionary to define how the Detector1 pipeline should be configured\n",
+    "\n",
+    "# Boilerplate dictionary setup\n",
+    "det1dict = {}\n",
+    "det1dict['group_scale'], det1dict['dq_init'], det1dict['saturation'] = {}, {}, {}\n",
+    "det1dict['ipc'], det1dict['superbias'], det1dict['refpix'] = {}, {}, {}\n",
+    "det1dict['linearity'], det1dict['persistence'], det1dict['dark_current'], = {}, {}, {}\n",
+    "det1dict['charge_migration'], det1dict['jump'], det1dict['ramp_fit'] = {}, {}, {}\n",
+    "det1dict['gain_scale'] = {}\n",
+    "\n",
+    "# Overrides for whether or not certain steps should be skipped\n",
+    "# skipping the persistence step\n",
+    "det1dict['persistence']['skip'] = True\n",
+    "#det1dict['jump']['find_showers'] = False # Turn off detection of cosmic ray showers\n",
+    "\n",
+    "# Overrides for various reference files\n",
+    "# Files should be in the base local directory or provide full path\n",
+    "#det1dict['dq_init']['override_mask'] = 'myfile.fits' # Bad pixel mask\n",
+    "#det1dict['saturation']['override_saturation'] = 'myfile.fits' # Saturation\n",
+    "#det1dict['reset']['override_reset'] = 'myfile.fits' # Reset\n",
+    "#det1dict['linearity']['override_linearity'] = 'myfile.fits' # Linearity\n",
+    "#det1dict['rscd']['override_rscd'] = 'myfile.fits' # RSCD\n",
+    "#det1dict['dark_current']['override_dark'] = 'myfile.fits' # Dark current subtraction\n",
+    "#det1dict['jump']['override_gain'] = 'myfile.fits' # Gain used by jump step\n",
+    "#det1dict['ramp_fit']['override_gain'] = 'myfile.fits' # Gain used by ramp fitting step\n",
+    "#det1dict['jump']['override_readnoise'] = 'myfile.fits' # Read noise used by jump step\n",
+    "#det1dict['ramp_fit']['override_readnoise'] = 'myfile.fits' # Read noise used by ramp fitting step\n",
+    "\n",
+    "# Turn on multi-core processing (off by default).  Choose what fraction of cores to use (quarter, half, or all)\n",
+    "det1dict['jump']['maximum_cores'] = 'half'\n",
+    "\n",
+    "# Alter parameters to optimize removal of snowball residuals (example)\n",
+    "#det1dict['jump']['expand_large_events'] = True\n",
+    "#det1dict['charge_migration']['signal_threshold']= X\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f8f107b-5f80-4674-bc34-2d88791e4409",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run Detector1 stage of pipeline, specifying:\n",
+    "# output directory to save *_rate.fits files\n",
+    "# save_results flag set to True so the rate files are saved\n",
+    "\n",
+    "if dodet1:\n",
+    "    for uncal in uncal_files:\n",
+    "        rate_result = Detector1Pipeline.call(uncal, output_dir=det1_dir, steps=det1dict, save_results=True,)\n",
+    "else:\n",
+    "    print('Skipping Detector1 processing')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4cc2b48-7ec7-4b59-b3ee-2dfdf0782c01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime for Detector1: {time1 - time0:0.4f} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fc5520a-6097-482b-b3e0-a6bf94cf7af3",
+   "metadata": {},
+   "source": [
+    "### Exploring the data\n",
+    "\n",
+    "Identify `*_rate.fits` files and verify which pipeline steps were run and\n",
+    "which calibration reference files were applied.\n",
+    "\n",
+    "The header contains information about which calibration steps were\n",
+    "completed and skipped and which reference files were used to process the\n",
+    "data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c122766-a545-4042-93e8-f68c18f62fdf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# find rate files\n",
+    "rate_files = sorted(glob.glob(os.path.join(det1_dir, '*_rate.fits')))\n",
+    "\n",
+    "# Read in file as datamodel\n",
+    "rate_f = datamodels.open(rate_files[0])\n",
+    "\n",
+    "rate_f.meta.cal_step.instance\n",
+    "\n",
+    "# Check which reference files were used to calibrate the dataset\n",
+    "rate_f.meta.ref_file.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "350808ee-9579-4cb5-8f02-a74904c91449",
+   "metadata": {},
+   "source": [
+    "## 6. Image2 Pipeline \n",
+    "\n",
+    "In the [Image2 stage of the pipeline](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_image2.html),\n",
+    "calibrated unrectified data products are created (`*_cal.fits` or\n",
+    "`*_calints.fits` files, depending on whether the input files are\n",
+    "`*_rate.fits` or `*_rateints.fits`). \n",
+    "\n",
+    "In this pipeline processing stage, the [world coordinate system (WCS)](https://jwst-pipeline.readthedocs.io/en/latest/jwst/assign_wcs/index.html#assign-wcs-step)\n",
+    "is assigned, the data are [flat fielded](https://jwst-pipeline.readthedocs.io/en/latest/jwst/flatfield/index.html#flatfield-step),\n",
+    "and a [photometric calibration](https://jwst-pipeline.readthedocs.io/en/latest/jwst/photom/index.html#photom-step)\n",
+    "is applied to convert from units of countrate (ADU/s) to surface brightness (MJy/sr).\n",
+    "\n",
+    "By default, the [background subtraction step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/background_step/index.html#background-step)\n",
+    "and the [resampling step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step)\n",
+    "are turned off for NIRISS at this stage of the pipeline. The background\n",
+    "subtraction is turned off since there is no background template for the\n",
+    "imaging mode and the local background is removed during the background\n",
+    "correction for photometric measurements around individual sources. The\n",
+    "resampling step occurs during the `Image3` stage by default. While the\n",
+    "resampling step can be turned on during the `Image2` stage to, e.g., \n",
+    "generate a source catalog for each image, the data quality from the\n",
+    "`Image3` stage will be better since the bad pixels, which adversely affect\n",
+    "both the centroids and photometry in individual images, will be mostly\n",
+    "removed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a091817-7a3c-4a60-a914-f9ac54d36e56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_image2 = time.perf_counter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b00fda2-a7c0-445a-bf23-0d9b4f050419",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a dictionary to define how the Image2 pipeline should be configured.\n",
+    "\n",
+    "# Boilerplate dictionary setup\n",
+    "image2dict = {}\n",
+    "image2dict['assign_wcs'], image2dict['flat_field'] = {}, {}\n",
+    "image2dict['photom'], image2dict['resample'] = {}, {}\n",
+    "\n",
+    "# Overrides for whether or not certain steps should be skipped (example)\n",
+    "#image2dict['resample']['skip'] = False\n",
+    "\n",
+    "# Overrides for various reference files\n",
+    "# Files should be in the base local directory or provide full path\n",
+    "#image2dict['assign_wcs']['override_distortion'] = 'myfile.asdf' # Spatial distortion (ASDF file)\n",
+    "#image2dict['assign_wcs']['override_filteroffset'] = 'myfile.asdf' # Imager filter offsets (ASDF file)\n",
+    "#image2dict['assign_wcs']['override_specwcs'] = 'myfile.asdf' # Spectral distortion (ASDF file)\n",
+    "#image2dict['assign_wcs']['override_wavelengthrange'] = 'myfile.asdf' # Wavelength channel mapping (ASDF file)\n",
+    "#image2dict['flat_field']['override_flat'] = 'myfile.fits' # Pixel flatfield\n",
+    "#image2dict['photom']['override_photom'] = 'myfile.fits' # Photometric calibration array"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "247170cd-a3ee-4d9d-b8b3-f930727f8abc",
+   "metadata": {},
+   "source": [
+    "Find and sort all of the input files, ensuring use of absolute paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d19cd4e6-cc38-4e26-8e8b-7fb143856940",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sstring = os.path.join(det1_dir, 'jw*rate.fits')  # Use files from the detector1 output folder\n",
+    "rate_files = sorted(glob.glob(sstring))\n",
+    "for ii in range(0, len(rate_files)):\n",
+    "    rate_files[ii] = os.path.abspath(rate_files[ii])\n",
+    "rate_files = np.array(rate_files)\n",
+    "print(f\"Found  {str(len(rate_files))} science files\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81d916e5-dd5d-472d-9aff-b2b4c86decf8",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run Image2 stage of pipeline, specifying:\n",
+    "# output directory to save *_cal.fits files\n",
+    "# save_results flag set to True so the rate files are saved\n",
+    "\n",
+    "if doimage2:\n",
+    "    for rate in rate_files:\n",
+    "        cal_result = Image2Pipeline.call(rate, output_dir=image2_dir, steps=image2dict, save_results=True)\n",
+    "else:\n",
+    "    print(\"Skipping Image2 processing.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d58b94d-e1d7-4b73-b598-756c99d81174",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time1 - time0:0.4f} seconds\")\n",
+    "print(f\"Runtime for Image2: {time1 - time_image2} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da57b7d0-95ef-4227-b730-6f54a3eaaa16",
+   "metadata": {},
+   "source": [
+    "### Verify which pipeline steps were run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27390bbd-ae2d-49e7-977a-59d3765c0946",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Identify *_cal.fits files\n",
+    "cal_files = sorted(glob.glob(os.path.join(image2_dir, '*_cal.fits')))\n",
+    "\n",
+    "cal_f = datamodels.open(cal_files[0])\n",
+    "\n",
+    "cal_f.meta.cal_step.instance\n",
+    "\n",
+    "# Check which reference files were used to calibrate the dataset\n",
+    "cal_f.meta.ref_file.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cfbb244-7af9-4cbf-90d9-08598378c16a",
+   "metadata": {},
+   "source": [
+    "## 7. Image3 Pipeline\n",
+    "\n",
+    "In the [Image3 stage of the pipeline](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_image3.html), the individual `*_cal.fits` files for each of the dither positions are combined to one single distortion corrected image. First, an [Association](https://jwst-pipeline.readthedocs.io/en/latest/jwst/associations/overview.html) needs to be created to inform the pipeline that these individual exposures are linked together. \n",
+    "\n",
+    "By default, the `Image3` stage of the pipeline performs the following steps on NIRISS data: \n",
+    "- [tweakreg](https://jwst-pipeline.readthedocs.io/en/latest/jwst/tweakreg/index.html#tweakreg-step) - creates source catalogs of pointlike sources for each input image. The source catalog for each input image is compared to each other to derive coordinate transforms to align the images relative to each other.\n",
+    "   - As of CRDS context `jwst_1156.pmap` and later, the `pars-tweakreg` parameter reference file for NIRISS performs an absolute astrometric correction to GAIA data release 3 by default (i.e., the `abs_refcat` parameter is set to `GAIADR3`). Though this default correction generally improves results compared with not doing this alignment, it can sometimes result in poor performance in crowded or sparse fields, so users are encouraged to check astrometric accuracy and revisit this step if necessary.\n",
+    "   - As of pipeline version 1.12.5, the default source finding algorithm is `DAOStarFinder` which can result in up to 0.5 pix uncertainties in the centroids for undersampled PSFs, like the NIRISS PSFs at short wavelengths [(Goudfrooij 2022)](https://www.stsci.edu/files/live/sites/www/files/home/jwst/documentation/technical-documents/_documents/JWST-STScI-008116.pdf). There are plans to update the default algorithm to `IRAFStarFinder` in future pipeline versions.\n",
+    "- [skymatch](https://jwst-pipeline.readthedocs.io/en/latest/jwst/skymatch/index.html#skymatch-step) - measures the background level from the sky to use as input into the subsequent `outlier detection` and `resample` steps.\n",
+    "- [outlier detection](https://jwst-pipeline.readthedocs.io/en/latest/jwst/outlier_detection/index.html#outlier-detection-step) - flags any remaining cosmic rays, bad pixels, or other artifacts not already flagged during the `DETECTOR1` stage of the pipeline, using all input images to create a median image so that outliers in individual images can be identified.\n",
+    "- [resample](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step) - resamples each input image based on its WCS and distortion information and creates a single undistorted image.\n",
+    "- [source catalog](https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/index.html#source-catalog-step) - creates a catalog of detected sources along with measured photometries and morphologies (i.e., point-like vs extended). Useful for quicklooks, but optimization is likely needed for specific science cases, which is an on-going investigation for the NIRISS team. Users may wish to experiment with changing the `snr_threshold` and `deblend` options. Modifications to the following parameters will not significantly improve data quality and it is advised to keep them at their default values: `aperture_ee1`, `aperture_ee2`, `aperture_ee3`, `ci1_star_threshold`, `ci2_star_threshold`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8e81dc9-78dd-4bba-879c-9dfa2a4da69c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_image3 = time.perf_counter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8159e63d-3c89-44ef-9a43-caaccd1abb4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up a dictionary to define how the Image3 pipeline should be configured\n",
+    "\n",
+    "# Boilerplate dictionary setup\n",
+    "image3dict = {}\n",
+    "image3dict['assign_mtwcs'], image3dict['tweakreg'], image3dict['skymatch'] = {}, {}, {}\n",
+    "image3dict['outlier_detection'], image3dict['resample'], image3dict['source_catalog'] = {}, {}, {}\n",
+    "\n",
+    "# Overrides for whether or not certain steps should be skipped (example)\n",
+    "#image3dict['outlier_detection']['skip'] = True\n",
+    "\n",
+    "# Overrides for various reference files\n",
+    "# Files should be in the base local directory or provide full path\n",
+    "#image3dict['source_catalog']['override_apcorr'] = 'myfile.fits'  # Aperture correction parameters\n",
+    "#image3dict['source_catalog']['override_abvegaoffset'] = 'myfile.asdf' # Data to convert from AB to Vega magnitudes (ASDF file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "962cae54-ab46-42fc-8767-c663d2782f4f",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "Set certain parameters here to adjusting performance for the outlier detection step\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc9c2436-a38b-4dbc-b4c0-a0bfeb739b6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Options for adjusting performance for the outlier detection step\n",
+    "#image3dict['outlier_detection']['weight_type'] = 'exptime'  # Change from the defaul 'ivm' weighting using during resampling\n",
+    "#image3dict['tweakreg']['starfinder'] = 'iraf'  # Improved performance. Default with 1.15.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e10da872-21ae-46c2-a3b1-f9cdefae3b36",
+   "metadata": {},
+   "source": [
+    "Find and sort all of the input files, ensuring use of absolute paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f0b5b47-62e9-4593-abc4-7ec630492e96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Science Files need the cal.fits files\n",
+    "sstring = os.path.join(image2_dir, 'jw*cal.fits')\n",
+    "cal_files = sorted(glob.glob(sstring))\n",
+    "for ii in range(0, len(cal_files)):\n",
+    "    cal_files[ii] = os.path.abspath(cal_files[ii])\n",
+    "calfiles = np.array(cal_files)\n",
+    "\n",
+    "print('Found {str(len(cal_files))} science files to process')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db5cb6f5-44a1-4f28-95dc-b23a97451465",
+   "metadata": {},
+   "source": [
+    "### Create Association File\n",
+    "\n",
+    "An association file lists the exposures to calibrated together in `Stage 3` of the pipeline. Note that an association file is available for download from MAST, with a filename of `*_asn.json`. Here we show how to create an association file to point to the data products created when processing data through the pipeline. Note that the output products will have a rootname that is specified by the `product_name` in the association file. For this tutorial, the rootname of the output products will be `image3_association`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b31f80f-8d7b-45ae-8537-15d0208637df",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create a Level 3 Association\n",
+    "if doimage3:\n",
+    "    associations = asn_from_list.asn_from_list(cal_files,\n",
+    "                                               rule=DMS_Level3_Base,\n",
+    "                                               product_name='image3_association')\n",
+    "    \n",
+    "    associations.data['asn_type'] = 'image3'\n",
+    "    associations.data['program'] = program\n",
+    "    \n",
+    "    # Format association as .json file\n",
+    "    asn_filename, serialized = associations.dump(format=\"json\")\n",
+    "\n",
+    "    # Write out association file\n",
+    "    association_im3 = os.path.join(sci_dir, asn_filename) \n",
+    "    with open(association_im3, \"w\") as fd:\n",
+    "        fd.write(serialized)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "629cad5b-e5a7-473e-8583-ad12cda55fa4",
+   "metadata": {},
+   "source": [
+    "### Run Image3 stage of the pipeline\n",
+    "\n",
+    "Given the grouped exposures in the association file, the `Image3` stage of the pipeline will produce:\n",
+    "- a `*_cr.fits` file produced by the `outlier_detection` step, where the `DQ` array marks the pixels flagged as outliers.\n",
+    "- a final combined, rectified image with name `*_i2d.fits`,\n",
+    "- a source catalog with name `*_cat.ecsv`,\n",
+    "- a segmentation map file (`*_segm.fits`) which has integer values at the pixel locations where a source is detected where the pixel values match the source ID number in the catalog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0cebfd8-a650-41a3-8ff0-a8fd43e079d6",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run Stage 3\n",
+    "\n",
+    "if doimage3:\n",
+    "    i2d_result = Image3Pipeline.call(association_im3, output_dir=image3_dir, steps=image3dict, save_results=True)\n",
+    "else:\n",
+    "    print('Skipping Spec3 processing')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f67d2c65-4614-4592-aa67-daa2de985013",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out the time benchmark\n",
+    "time1 = time.perf_counter()\n",
+    "print(f\"Runtime so far: {time1 - time0:0.4f} seconds\")\n",
+    "print(f\"Runtime for Image3: {time1 - time_image3} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bcb6c40-fbb8-4226-b620-64b0c02c8ceb",
+   "metadata": {},
+   "source": [
+    "### Verify which pipeline steps were run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c754530a-d4e2-493b-bf8b-bf8d1ad08770",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Identify *_i2d file and open as datamodel\n",
+    "i2d = glob.glob(os.path.join(image3_dir, \"*_i2d.fits\"))[0]\n",
+    "i2d_f = datamodels.open(i2d)\n",
+    "\n",
+    "i2d_f.meta.cal_step.instance\n",
+    "\n",
+    "# Check which reference files were used to calibrate the dataset\n",
+    "i2d_f.meta.ref_file.instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46be5421-7fc8-4d96-b2cd-2484f294e082",
+   "metadata": {},
+   "source": [
+    "## 8. Visualize the data\n",
+    "\n",
+    "Display datasets from the diferent stages to understand how the pipeline works.\n",
+    "\n",
+    "### Display uncalibrated image\n",
+    "\n",
+    "We can visualize an uncalibrated dataset that will show detector artifacts that will be removed when calibrating the data through the `DETECTOR1` stage of the pipeline. Uncalibrated data files thus are 4D: nintegrations x ngroups x nrows x ncols. Here, we are visualizing the full detector (i.e., all columns and rows) and the 1st group.\n",
+    "\n",
+    "We are using the [Imviz tool](https://jdaviz.readthedocs.io/en/latest/imviz/index.html) within the `jdaviz` package to visualize the NIRISS image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1db43de4-896e-4eb4-8e92-aecf67eed5be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an Imviz instance and set up default viewer\n",
+    "imviz_uncal = Imviz()\n",
+    "viewer_uncal = imviz_uncal.default_viewer\n",
+    "\n",
+    "# Read in the science array for our visualization dataset:\n",
+    "uncal_science = examine.data\n",
+    "\n",
+    "# Load the dataset into Imviz\n",
+    "imviz_uncal.load_data(uncal_science[0, 1, :, :])\n",
+    "\n",
+    "# Visualize the dataset:\n",
+    "imviz_uncal.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2d33e40-64b1-4d24-9a72-af586ccddf0c",
+   "metadata": {},
+   "source": [
+    "Adjust settings for the viewer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00479015-d39a-493e-9c0f-300823901bc1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer_uncal.stretch = 'sqrt'\n",
+    "viewer_uncal.set_colormap('Viridis')\n",
+    "viewer_uncal.cuts = '99.5%'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ff813f4-f9d6-4765-b882-48f954b8969d",
+   "metadata": {},
+   "source": [
+    "### Display rate image\n",
+    "\n",
+    "Visualize a countrate image, using the dataset from the first dither position as an example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "176e27f5-f59f-4a6c-960b-4d688288eae3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an Imviz instance and set up default viewer\n",
+    "imviz_rate = Imviz()\n",
+    "viewer_rate = imviz_rate.default_viewer\n",
+    "\n",
+    "# Read in the science array for our visualization dataset:\n",
+    "rate_science = rate_f.data\n",
+    "\n",
+    "# Load the dataset into Imviz\n",
+    "imviz_rate.load_data(rate_science)\n",
+    "\n",
+    "# Visualize the dataset:\n",
+    "imviz_rate.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb6f488c-eaef-4b96-9284-07f0e1d13f6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer_rate.stretch = 'sqrt'\n",
+    "viewer_rate.set_colormap('Viridis')\n",
+    "viewer_rate.cuts = '95%'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19b9d7e4-536c-4661-ac9a-d21e7daf1389",
+   "metadata": {},
+   "source": [
+    "### Display cal image\n",
+    "\n",
+    "Visualize a calibrated image, using the dataset from the first dither position as an example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15455eda-74b5-453b-b5c9-e21b48b73446",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an Imviz instance and set up default viewer\n",
+    "imviz_cal = Imviz()\n",
+    "viewer_cal = imviz_cal.default_viewer\n",
+    "\n",
+    "# Read in the science array for our visualization dataset:\n",
+    "cal_science = cal_f.data\n",
+    "\n",
+    "# Load the dataset into Imviz\n",
+    "imviz_cal.load_data(cal_science)\n",
+    "\n",
+    "# Visualize the dataset:\n",
+    "imviz_cal.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b89947f-c9c6-4eee-a4e1-0f880d28bf31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer_cal.stretch = 'sqrt'\n",
+    "viewer_cal.set_colormap('Viridis')\n",
+    "viewer_cal.cuts = '95%'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d44a0de-774a-4d63-8de9-80a9c6aa24b2",
+   "metadata": {},
+   "source": [
+    "### Display combined image\n",
+    "\n",
+    "Visualize the drizzle-combined image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6f1ed63-0bed-412b-ab04-54caa7d61bbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an Imviz instance and set up default viewer\n",
+    "imviz_i2d = Imviz()\n",
+    "viewer_i2d = imviz_i2d.default_viewer\n",
+    "\n",
+    "# Read in the science array for our visualization dataset:\n",
+    "i2d_science = i2d_f.data\n",
+    "\n",
+    "# Load the dataset into Imviz\n",
+    "imviz_i2d.load_data(i2d_science)\n",
+    "\n",
+    "# Visualize the dataset:\n",
+    "imviz_i2d.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d22a117-e4cf-4d2f-9fec-f52545c8aa5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer_i2d.stretch = 'sqrt'\n",
+    "viewer_i2d.set_colormap('Viridis')\n",
+    "viewer_i2d.cuts = '95%'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "018733eb-07ec-44a4-a5a7-d6d2f27d193a",
+   "metadata": {},
+   "source": [
+    "## <a id='detections'>Visualize Detected Sources</a>\n",
+    "Using the source catalog created by the `IMAGE3` stage of the pipeline, mark the detected sources, using different markers for point sources and extended sources. The source catalog is saved in `image3/image3_association_cat.ecsv` file. We will need to read in the `i2d` file again to make sure the world coordinate system (WCS) info is read in."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ad6ee55-f940-4be3-96c9-114bc83eb784",
+   "metadata": {},
+   "source": [
+    "### Read in catalog file and identify point/extended sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32235fdc-4ec2-42e6-89e7-b9f62824e179",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalog_file = glob.glob(os.path.join(image3_dir, \"*_cat.ecsv\"))[0]\n",
+    "catalog = Table.read(catalog_file)\n",
+    "\n",
+    "# To identify point/extended sources, use the 'is_extended' column in the source catalog\n",
+    "pt_src, = np.where(~catalog['is_extended'])\n",
+    "ext_src, = np.where(catalog['is_extended'])\n",
+    "\n",
+    "# Define coordinates of point and extended sources\n",
+    "pt_coord = Table({'coord': [SkyCoord(ra=catalog['sky_centroid'][pt_src].ra,\n",
+    "                                     dec=catalog['sky_centroid'][pt_src].dec)]})\n",
+    "ext_coord = Table({'coord': [SkyCoord(ra=catalog['sky_centroid'][ext_src].ra,\n",
+    "                                      dec=catalog['sky_centroid'][ext_src].dec)]})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be9e9069-375d-431b-bbfb-e84e6cefc2d4",
+   "metadata": {},
+   "source": [
+    "### Mark the extended and point sources on the image\n",
+    "\n",
+    "Display combined image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "302bc3ce-358d-4ea8-a533-37b9a9a2152c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read in i2d file to Imviz\n",
+    "imviz_cat = Imviz()\n",
+    "viewer_cat = imviz_cat.default_viewer\n",
+    "imviz_cat.load_data(i2d)\n",
+    "\n",
+    "# Adjust settings for viewer\n",
+    "viewer_cat.stretch = 'sqrt'\n",
+    "viewer_cat.set_colormap('Viridis')\n",
+    "viewer_cat.cuts = '95%'\n",
+    "\n",
+    "imviz_cat.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb9dc081-7a24-442c-bf86-ed2faa6cf342",
+   "metadata": {},
+   "source": [
+    "Point sources will be marked by small pink circles and extended sources will be marked by larger white circles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcb8f619-3807-44d1-a8d9-fbf41abb5522",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add marker for point sources:\n",
+    "viewer_cat.marker = {'color': 'pink', 'markersize': 50, 'fill': False}\n",
+    "\n",
+    "viewer_cat.add_markers(pt_coord, use_skycoord=True, marker_name='point_sources')\n",
+    "\n",
+    "# Add marker for extended sources:\n",
+    "viewer_cat.marker = {'color': 'white', 'markersize': 100, 'fill': False}\n",
+    "\n",
+    "viewer_cat.add_markers(ext_coord, use_skycoord=True, marker_name='extended_sources')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/NIRISS/requirements.txt
+++ b/notebooks/NIRISS/requirements.txt
@@ -1,3 +1,5 @@
-numpy
-crds
-jwst>=1.13.3
+numpy<2.0
+jwst==1.14.0
+astroquery
+jdaviz
+astropy>=4.3.1


### PR DESCRIPTION
Changes to Notebook:
———————————————————

1. Notebook chaged name to match format
2. changed the requirement files to set numpy <2.0 and remove CRDS call from there. Changed version of the pipieline to run 1.14.0
3. Added author field. 
4. NIRISS Team reviewed Recent Changes section 
5. Added section to configure CRDS
6. Changed the organization to agree with that of the template notebook. Mainly move the import packages after configuration of CRDS. 
7. Added demo mode to import from astroquery
8. Moved information about restricting data to one filter to the section talking about getting the data from MAST
9. Removed sections for getting the data from Box and added sections to get the data from MAST in demo mode
10. Added section to set the directories as the MRS notebook
11. Removed mention of WFSS and AMI because these do not apply to this notebook.
12. Removed section about read-the-docs pipeline documentation as it repeats what is provided in JDox and could become out of sync. 
13. Added time benchmark counters for all stages. NIRISS changed them to be integer seconds.
14. NIRISS team changed the way the reference files are printed to a separate cell
15. Added In Detector 1 a new section to define a dictionary with the steps that run and examples of how to override parameters or reference files via a dictionary.
18. Added dictionary and parameters for Image 2
19. NIRISS team did check the parameters for Image2 run
20. Added dictionary and parameters for Image 3
21. NIRISS team did check parameters for Image3 run
22. Moved to save the association Image3 file in the ObsXXX directory and changed cal files get the full path rather than relative paths (which was crashing the run).
23. Moved plotting or data visualization to the end