### PR TITLE
Downgrade gwcs pin due to recent breaking gwcs update

### DIFF
--- a/notebooks/MIRI/Imaging/requirements.txt
+++ b/notebooks/MIRI/Imaging/requirements.txt
@@ -2,3 +2,4 @@ numpy<2.0
 jwst==1.15.1
 astroquery
 jupyter
+gwcs==0.21.0

--- a/notebooks/MIRI/MRS/requirements.txt
+++ b/notebooks/MIRI/MRS/requirements.txt
@@ -2,3 +2,4 @@ numpy<2.0
 jwst==1.15.1
 astroquery
 jupyter
+gwcs==0.21.0

--- a/notebooks/NIRCAM/Imaging/requirements.txt
+++ b/notebooks/NIRCAM/Imaging/requirements.txt
@@ -3,3 +3,4 @@ jwst==1.15.1
 astroquery
 jdaviz
 astropy>=4.3.1
+gwcs==0.21.0

--- a/notebooks/NIRISS/Imaging/requirements.txt
+++ b/notebooks/NIRISS/Imaging/requirements.txt
@@ -3,3 +3,4 @@ jwst==1.15.1
 astroquery
 jdaviz
 astropy>=4.3.1
+gwcs==0.21.0


### PR DESCRIPTION
This update fixes the requirements files for pipeline versions 1.15.1 and 1.16.1 to ensure use of a compatible gwcs version.