### PR TITLE
Remove old directory

### DIFF
--- a/notebooks/NIRSPEC/Slit/requirements.txt
+++ b/notebooks/NIRSPEC/Slit/requirements.txt
@@ -1,3 +1,0 @@
-numpy
-crds
-jwst>=1.13.3


### PR DESCRIPTION
This PR remove the old 'NIRSPEC/Slit' directory since that notebook is at 'NIRSPEC/FSlit' instead.