### PR TITLE
Add clean_flicker_noise option to NIRCam imaging notebook

### DIFF
--- a/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb
+++ b/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb
@@ -16,7 +16,7 @@
     "#  NIRCam Imaging Pipeline Notebook\n",
     "\n",
     "**Authors**: B. Hilbert, based on the NIRISS imaging notebook by R. Diaz<br>\n",
-    "**Last Updated**: January 31, 2025<br>\n",
+    "**Last Updated**: February 25, 2025<br>\n",
     "**Pipeline Version**: 1.17.1 (Build 11.2)"
    ]
   },
@@ -62,7 +62,8 @@
     "Nov 11, 2024: Comment out line to set the context<br>\n",
     "Nov 18, 2024: Do not require both SW and LW user-provided data<br>\n",
     "November 22, 2024: Updates to workflow when skipping pipeline modules<br>\n",
-    "January 31, 2025: Update to build 11.2, update JDAViz Links Control to Orientation call<br><br>"
+    "January 31, 2025: Update to build 11.2, update JDAViz Links Control to Orientation call<br>\n",
+    "February 25, 2025: Add optional call to clean_flicker_noise<br>"
    ]
   },
   {
@@ -827,8 +828,8 @@
     "det1dict['group_scale'], det1dict['dq_init'], det1dict['saturation'] = {}, {}, {}\n",
     "det1dict['ipc'], det1dict['superbias'], det1dict['refpix'] = {}, {}, {}\n",
     "det1dict['linearity'], det1dict['persistence'], det1dict['dark_current'], = {}, {}, {}\n",
-    "det1dict['charge_migration'], det1dict['jump'], det1dict['ramp_fit'] = {}, {}, {}\n",
-    "det1dict['gain_scale'] = {}\n",
+    "det1dict['charge_migration'], det1dict['jump'], det1dict['clean_flicker_noise'] = {}, {}, {}\n",
+    "det1dict['ramp_fit'], det1dict['gain_scale'] = {}, {}\n",
     "\n",
     "# Overrides for whether or not certain steps should be skipped\n",
     "# skipping the persistence step\n",
@@ -852,7 +853,14 @@
     "det1dict['jump']['maximum_cores'] = 'half'\n",
     "\n",
     "# Explicitly turn on snowball correction. (Even though it is on by default)\n",
-    "det1dict['jump']['expand_large_events'] = True"
+    "det1dict['jump']['expand_large_events'] = True\n",
+    "\n",
+    "# Turn on 1/f correction if desired\n",
+    "# For guidance see https://jwst-docs.stsci.edu/known-issues-with-jwst-data/1-f-noise\n",
+    "#det1dict['clean_flicker_noise']['skip'] = False\n",
+    "#det1dict['clean_flicker_noise']['fit_method'] = 'median' # 'median' or 'fft'\n",
+    "#det1dict['clean_flicker_noise']['background_method'] = 'median' # 'median' or 'model'\n",
+    "#det1dict['clean_flicker_noise']['fit_by_channel'] = False"
    ]
   },
   {


### PR DESCRIPTION
This PR adds a commented-out call to the new clean_flicker_noise step to the NIRCam imaging notebook.