### PR TITLE
Update NIRCam imaging notebook to work with JDAviz 4.2.1

### DIFF
--- a/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb
+++ b/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb
@@ -16,7 +16,7 @@
     "#  NIRCam Imaging Pipeline Notebook\n",
     "\n",
     "**Authors**: B. Hilbert, based on the NIRISS imaging notebook by R. Diaz<br>\n",
-    "**Last Updated**: February 25, 2025<br>\n",
+    "**Last Updated**: April 02, 2025<br>\n",
     "**Pipeline Version**: 1.17.1 (Build 11.2)"
    ]
   },
@@ -63,7 +63,8 @@
     "Nov 18, 2024: Do not require both SW and LW user-provided data<br>\n",
     "November 22, 2024: Updates to workflow when skipping pipeline modules<br>\n",
     "January 31, 2025: Update to build 11.2, update JDAViz Links Control to Orientation call<br>\n",
-    "February 25, 2025: Add optional call to clean_flicker_noise<br>"
+    "February 25, 2025: Add optional call to clean_flicker_noise<br>\n",
+    "April 02, 2025: Update JDAviz call to work with JDAviz 4.2.1<br>"
    ]
   },
   {
@@ -1653,9 +1654,8 @@
     "    imviz_color.load_data(sw_i2d_file, data_label='sw')\n",
     "    imviz_color.load_data(lw_i2d_file, data_label='lw')\n",
     "\n",
-    "    # Link images by WCS (without affine approximation)\n",
-    "    imviz_color.plugins['Orientation'].link_type = 'WCS'\n",
-    "    imviz_color.plugins['Orientation'].wcs_use_affine = False"
+    "    # Link images by WCS\n",
+    "    imviz_color.link_data(align_by='wcs')"
    ]
   },
   {

--- a/notebooks/NIRCAM/Imaging/requirements.txt
+++ b/notebooks/NIRCAM/Imaging/requirements.txt
@@ -1,3 +1,3 @@
 jwst==1.17.1
 astroquery
-jdaviz
+jdaviz==4.2.1


### PR DESCRIPTION
This PR updates the NIRCam imaging notebook to fix an incompatibility with the latest version of jdaviz 4.2.1.  Also pins the JDAviz dependency to 4.2.1.