### PR TITLE
Update unchanged notebooks to jwst1.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![DOI](https://zenodo.org/badge/782173509.svg)](https://doi.org/10.5281/zenodo.15060584)
 
 > [!IMPORTANT]
-> JWST requires a C compiler for dependencies and is currently limited to Python 3.10, 3.11, or 3.12.
+> JWST requires a C compiler for dependencies and is currently limited to Python 3.11, 3.12, or 3.13.
 
 > [!NOTE]
 > Linux and MacOS platforms are tested and supported.  Windows is not currently supported.
@@ -20,16 +20,16 @@ The following table summarizes the notebooks currently available and the JWST [p
 
 | Instrument | Observing Mode | JWST Build | ``jwst`` version | Notebook                                         |
 |------------|----------------|------------|--------------------------|-----------------------------------------------|
-| MIRI       | Coronagraphy   | 11.2       | 1.17.1 | [JWPipeNB-MIRI-Coron.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb) |
-| MIRI       | Imaging        | 11.2       | 1.17.1 | [JWPipeNB-MIRI-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb) |
-| MIRI       | Imaging TSO    | 11.2       | 1.17.1 | [JWPipeNB-MIRI-imaging-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb)  |
-| MIRI       | LRS Slit       | 11.2       | 1.17.1 | [JWPipeNB-MIRI-LRS-slit.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb)  |
-| MIRI       | LRS Slitless   | 11.2       | 1.17.1 | [JWPipeNB-MIRI-LRS-slitless-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slitless-TSO/JWPipeNB-MIRI-LRS-slitless-TSO.ipynb)  |
+| MIRI       | Coronagraphy   | 11.3       | 1.18.0 | [JWPipeNB-MIRI-Coron.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb) |
+| MIRI       | Imaging        | 11.3       | 1.18.0 | [JWPipeNB-MIRI-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb) |
+| MIRI       | Imaging TSO    | 11.3       | 1.18.0 | [JWPipeNB-MIRI-imaging-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb)  |
+| MIRI       | LRS Slit       | 11.3       | 1.18.0 | [JWPipeNB-MIRI-LRS-slit.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb)  |
+| MIRI       | LRS Slitless   | 11.3       | 1.18.0 | [JWPipeNB-MIRI-LRS-slitless-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slitless-TSO/JWPipeNB-MIRI-LRS-slitless-TSO.ipynb)  |
 | MIRI       | MRS            | 11.2       | 1.17.1 | [JWPipeNB-MIRI-MRS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/MRS/JWPipeNB-MIRI-MRS.ipynb)  |
-| NIRCam     | Coronagraphy   | 11.2       | 1.17.1 | [JWPipeNB-nircam-coronagraphy.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/Coronagraphy/JWPipeNB-nircam-coronagraphy.ipynb)  |
-| NIRCam     | Imaging        | 11.2       | 1.17.1 | [JWPipeNB-nircam-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb)  |
+| NIRCam     | Coronagraphy   | 11.3       | 1.18.0 | [JWPipeNB-nircam-coronagraphy.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/Coronagraphy/JWPipeNB-nircam-coronagraphy.ipynb)  |
+| NIRCam     | Imaging        | 11.3       | 1.18.0 | [JWPipeNB-nircam-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb)  |
 | NIRISS     | AMI            | 11.2       | 1.17.1 | [JWPipeNB-niriss-ami.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/AMI/JWPipeNB-niriss-ami.ipynb)  |
-| NIRISS     | Imaging        | 11.2       | 1.17.1 | [JWPipeNB-niriss-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/Imaging/JWPipeNB-niriss-imaging.ipynb)  |
+| NIRISS     | Imaging        | 11.3       | 1.18.0 | [JWPipeNB-niriss-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/Imaging/JWPipeNB-niriss-imaging.ipynb)  |
 | NIRSpec    | BOTS           | 11.2       | 1.17.1 | [JWPipeNB-NIRSpec-BOTS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/BOTS/JWPipeNB-NIRSpec-BOTS.ipynb)  |
 | NIRSpec    | Fixed Slit     | 11.2       | 1.17.1 | [JWPipeNB-NIRSpec-FS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/FSlit/JWPipeNB-NIRSpec-FS.ipynb)  |
 | NIRSpec    | IFU            | 11.2       | 1.17.1 | [JWPipeNB-NIRSpec-IFU.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/IFU/JWPipeNB-NIRSpec-IFU.ipynb)  |

--- a/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb
+++ b/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb
@@ -23,8 +23,8 @@
    "metadata": {},
    "source": [
     "**Authors**: B. Nickson; MIRI branch<br>\n",
-    "**Last Updated**: Feb 6, 2024<br>\n",
-    "**Pipeline Version**: 1.17.1 (Build 11.2)"
+    "**Last Updated**: May 5, 2025<br>\n",
+    "**Pipeline Version**: 1.18.0 (Build 11.3)"
    ]
   },
   {
@@ -59,7 +59,8 @@
     "[https://github.com/spacetelescope/jwst-pipeline-notebooks/](https://github.com/spacetelescope/jwst-pipeline-notebooks/)\n",
     "\n",
     "**Recent Changes**:<br>\n",
-    "Jan 28, 2025: Migrate from the `Coronagraphy_ExambleNB` notebook, update to Build 11.2 (jwst 1.17.1)."
+    "Jan 28, 2025: Migrate from the `Coronagraphy_ExambleNB` notebook, update to Build 11.2 (jwst 1.17.1).<br>\n",
+    "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)"
    ]
   },
   {
@@ -1587,7 +1588,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/Coronagraphy/requirements.txt
+++ b/notebooks/MIRI/Coronagraphy/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.17.1
+jwst==1.18.0
 astroquery
 jupyter

--- a/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb
+++ b/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb
@@ -16,8 +16,8 @@
     "# MIRI Imaging TSO Pipeline Notebook\n",
     "\n",
     "**Authors**: Ian Wong; MIRI branch<br>\n",
-    "**Last Updated**: February 2, 2025<br>\n",
-    "**Pipeline Version**: 1.17.1 (Build 11.2)"
+    "**Last Updated**: May 5, 2025<br>\n",
+    "**Pipeline Version**: 1.18.0 (Build 11.3)"
    ]
   },
   {
@@ -52,7 +52,8 @@
     "https://github.com/spacetelescope/jwst-pipeline-notebooks/\n",
     "\n",
     "**Recent Changes**:<br>\n",
-    "Feb 2 2025: Notebook created."
+    "Feb 2 2025: Notebook created.<br>\n",
+    "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)"
    ]
   },
   {
@@ -1006,7 +1007,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/Imaging-TSO/requirements.txt
+++ b/notebooks/MIRI/Imaging-TSO/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.17.1
+jwst==1.18.0
 astroquery
 jupyter

--- a/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb
+++ b/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb
@@ -486,7 +486,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "764fa682",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "scroll-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "if demo_mode:\n",
@@ -986,7 +990,10 @@
    "execution_count": null,
    "id": "81d916e5-dd5d-472d-9aff-b2b4c86decf8",
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
    },
    "outputs": [],
    "source": [
@@ -1212,7 +1219,10 @@
    "execution_count": null,
    "id": "e0cebfd8-a650-41a3-8ff0-a8fd43e079d6",
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
    },
    "outputs": [],
    "source": [
@@ -1285,7 +1295,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4994ba3a-1022-4061-85b6-b2bd08477852",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "scroll-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "if doviz:\n",
@@ -1352,7 +1366,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "32235fdc-4ec2-42e6-89e7-b9f62824e179",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "scroll-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "if doviz:\n",
@@ -1388,7 +1406,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "eafd7ef5-f2c1-4698-8a66-1b8009871c02",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "scroll-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "if doviz:\n",
@@ -1429,6 +1451,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb
+++ b/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb
@@ -16,8 +16,8 @@
     "# MIRI Imaging Pipeline Notebook\n",
     "\n",
     "**Authors**: M. Cracraft<br>\n",
-    "**Last Updated**: January 16, 2025<br>\n",
-    "**Pipeline Version**: 1.17.1 (Build 11.2)"
+    "**Last Updated**: May 5, 2025<br>\n",
+    "**Pipeline Version**: 1.18.0 (Build 11.3)"
    ]
   },
   {
@@ -53,7 +53,8 @@
     "**Recent Changes**:<br>\n",
     "September 25, 2024: original notebook released<br>\n",
     "November 22, 2024: Updates to workflow when skipping pipeline modules<br>\n",
-    "January 16, 2025: Add handling for dedicated backgrounds, update to jwst 1.17.1<br>"
+    "January 16, 2025: Add handling for dedicated backgrounds, update to jwst 1.17.1<br>\n",
+    "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)"
    ]
   },
   {
@@ -734,7 +735,10 @@
    "execution_count": null,
    "id": "0f8f107b-5f80-4674-bc34-2d88791e4409",
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "tags": [
+     "scroll-output"
+    ]
    },
    "outputs": [],
    "source": [
@@ -1440,7 +1444,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/Imaging/requirements.txt
+++ b/notebooks/MIRI/Imaging/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.17.1
+jwst==1.18.0
 astroquery
 jupyter

--- a/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb
+++ b/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb
@@ -23,8 +23,8 @@
    "metadata": {},
    "source": [
     "**Authors**: Ian Wong; MIRI branch<br>\n",
-    "**Last Updated**: February 1, 2025<br>\n",
-    "**Pipeline Version**: 1.17.1 (Build 11.2)"
+    "**Last Updated**: May 5, 2025<br>\n",
+    "**Pipeline Version**: 1.18.0 (Build 11.3)"
    ]
   },
   {
@@ -56,7 +56,8 @@
     "https://github.com/spacetelescope/jwst-pipeline-notebooks/\n",
     "\n",
     "**Recent Changes**:<br>\n",
-    "Feb 1 2025: Notebook created."
+    "Feb 1 2025: Notebook created.<br>\n",
+    "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)"
    ]
   },
   {
@@ -1074,7 +1075,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/LRS-slit/requirements.txt
+++ b/notebooks/MIRI/LRS-slit/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.17.1
+jwst==1.18.0
 astroquery
 jupyter

--- a/notebooks/MIRI/LRS-slitless-TSO/JWPipeNB-MIRI-LRS-slitless-TSO.ipynb
+++ b/notebooks/MIRI/LRS-slitless-TSO/JWPipeNB-MIRI-LRS-slitless-TSO.ipynb
@@ -23,8 +23,8 @@
    "metadata": {},
    "source": [
     "**Authors**: Ian Wong; MIRI branch<br>\n",
-    "**Last Updated**: February 1, 2025<br>\n",
-    "**Pipeline Version**: 1.17.1 (Build 11.2)"
+    "**Last Updated**: May 5, 2025<br>\n",
+    "**Pipeline Version**: 1.18.0 (Build 11.3)"
    ]
   },
   {
@@ -58,7 +58,8 @@
     "https://github.com/spacetelescope/jwst-pipeline-notebooks/\n",
     "\n",
     "**Recent Changes**:<br>\n",
-    "Feb 1 2025: Notebook created."
+    "Feb 1 2025: Notebook created.<br>\n",
+    "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)"
    ]
   },
   {
@@ -1235,7 +1236,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/LRS-slitless-TSO/requirements.txt
+++ b/notebooks/MIRI/LRS-slitless-TSO/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.17.1
+jwst==1.18.0
 astroquery
 jupyter

--- a/notebooks/NIRCAM/Coronagraphy/JWPipeNB-nircam-coronagraphy.ipynb
+++ b/notebooks/NIRCAM/Coronagraphy/JWPipeNB-nircam-coronagraphy.ipynb
@@ -16,8 +16,8 @@
     "#  NIRCam Coronagraphy Pipeline Notebook\n",
     "\n",
     "**Authors**: B. Sunnquist, based on the NIRISS/NIRCam imaging notebooks by R. Diaz and B. Hilbert<br>\n",
-    "**Last Updated**: February 26, 2025<br>\n",
-    "**Pipeline Version**: 1.17.1 (Build 11.2)"
+    "**Last Updated**: May 5, 2025<br>\n",
+    "**Pipeline Version**: 1.18.0 (Build 11.3)"
    ]
   },
   {
@@ -53,7 +53,8 @@
     "https://github.com/spacetelescope/jwst-pipeline-notebooks/\n",
     "\n",
     "**Recent Changes**:<br>\n",
-    "Feb 26, 2025: original notebook created<br>"
+    "Feb 26, 2025: original notebook created<br>\n",
+    "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)"
    ]
   },
   {
@@ -1316,7 +1317,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRCAM/Coronagraphy/requirements.txt
+++ b/notebooks/NIRCAM/Coronagraphy/requirements.txt
@@ -1,2 +1,2 @@
-jwst==1.17.1
+jwst==1.18.0
 astroquery

--- a/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb
+++ b/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb
@@ -16,8 +16,8 @@
     "#  NIRCam Imaging Pipeline Notebook\n",
     "\n",
     "**Authors**: B. Hilbert, based on the NIRISS imaging notebook by R. Diaz<br>\n",
-    "**Last Updated**: April 02, 2025<br>\n",
-    "**Pipeline Version**: 1.17.1 (Build 11.2)"
+    "**Last Updated**: May 5, 2025<br>\n",
+    "**Pipeline Version**: 1.18.0 (Build 11.3)"
    ]
   },
   {
@@ -64,7 +64,8 @@
     "November 22, 2024: Updates to workflow when skipping pipeline modules<br>\n",
     "January 31, 2025: Update to build 11.2, update JDAViz Links Control to Orientation call<br>\n",
     "February 25, 2025: Add optional call to clean_flicker_noise<br>\n",
-    "April 02, 2025: Update JDAviz call to work with JDAviz 4.2.1<br>"
+    "April 02, 2025: Update JDAviz call to work with JDAviz 4.2.1<br>\n",
+    "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)"
    ]
   },
   {
@@ -1966,7 +1967,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRCAM/Imaging/requirements.txt
+++ b/notebooks/NIRCAM/Imaging/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.17.1
+jwst==1.18.0
 astroquery
 jdaviz==4.2.1

--- a/notebooks/NIRISS/Imaging/JWPipeNB-niriss-imaging.ipynb
+++ b/notebooks/NIRISS/Imaging/JWPipeNB-niriss-imaging.ipynb
@@ -13,11 +13,11 @@
    "id": "0393e357-9d9d-4516-b28d-4d335fad33a0",
    "metadata": {},
    "source": [
-    "##### NIRISS Imaging Pipeline Notebook\n",
+    "# NIRISS Imaging Pipeline Notebook\n",
     "\n",
     "**Authors**: S. LaMassa, R. Diaz<br>\n",
-    "**Last Updated**: January 31, 2025<br>\n",
-    "**Pipeline Version**: 1.17.1 (Build 11.2)"
+    "**Last Updated**: May 5, 2025<br>\n",
+    "**Pipeline Version**: 1.18.0 (Build 11.3)"
    ]
   },
   {
@@ -66,7 +66,8 @@
     "centroiding algorithm used in the `Image3` tweakreg step of the pipeline for NIRISS imaging, as of \n",
     "pipeline version 1.14.0 (build 10.2).<br>\n",
     "November 22, 2024: Updates to workflow when skipping pipeline modules<br>\n",
-    "January 31, 2025: Update to build 11.2, no significant changes.<br>"
+    "January 31, 2025: Update to build 11.2, no significant changes.<br>\n",
+    "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)"
    ]
   },
   {
@@ -1345,7 +1346,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRISS/Imaging/requirements.txt
+++ b/notebooks/NIRISS/Imaging/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.17.1
+jwst==1.18.0
 astroquery
 jdaviz


### PR DESCRIPTION
This PR updates assorted pipeline notebooks with no other changes to latest jwst version 1.18.0.

Tagging @cracraft @ianyuwong @bhilbert4 @slamassa @brynickson @bsunnquist  FYI, although the only relevant change is to update requirements file to 1.18.0 and add a corresponding note to the notebook header.