### PR TITLE
Update code owners for nirspec, consistency

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,11 @@
 /notebooks/MIRI/LRS-slit/   @ianyuwong  @skendrew  @drlaw1558
 /notebooks/MIRI/LRS-slitless-TSO/   @ianyuwong  @skendrew  @drlaw1558
 /notebooks/MIRI/MRS/   @kilarson  @skendrew  @drlaw1558
+/notebooks/NIRISS/AMI/   @spacetelescope/niriss  @drlaw1558
 /notebooks/NIRISS/Imaging/   @spacetelescope/niriss  @drlaw1558
-/notebooks/NIRSPEC/Slit/   @spacetelescope/nirspec  @drlaw1558
-/notebooks/NIRCAM/Imaging/   @aliciacanipe  @bhilbert4  @bsunnquist  @drlaw1558
+/notebooks/NIRSPEC/BOTS/   @hayescr  @kglidic  @drlaw1558
+/notebooks/NIRSPEC/FSlit/   @hayescr  @kglidic  @drlaw1558
+/notebooks/NIRSPEC/IFU/   @hayescr  @kglidic  @drlaw1558
+/notebooks/NIRSPEC/MOS/   @hayescr  @kglidic  @drlaw1558
 /notebooks/NIRCAM/Coronagraphy/   @aliciacanipe  @bhilbert4  @bsunnquist  @drlaw1558
+/notebooks/NIRCAM/Imaging/   @aliciacanipe  @bhilbert4  @bsunnquist  @drlaw1558


### PR DESCRIPTION
@sosey Another code owners update, this time for NIRSPEC.  Also filled in a missing AMI notebook and reordered things.