### PR TITLE
Update all notebooks to jwst1.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ The following table summarizes the notebooks currently available and the JWST [p
 
 | Instrument | Observing Mode | JWST Build | ``jwst`` version | Notebook                                         |
 |------------|----------------|------------|--------------------------|-----------------------------------------------|
-| MIRI       | Coronagraphy   | 11.3       | 1.18.0 | [JWPipeNB-MIRI-Coron.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb) |
-| MIRI       | Imaging        | 11.3       | 1.18.0 | [JWPipeNB-MIRI-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb) |
-| MIRI       | Imaging TSO    | 11.3       | 1.18.0 | [JWPipeNB-MIRI-imaging-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb)  |
-| MIRI       | LRS Slit       | 11.3       | 1.18.0 | [JWPipeNB-MIRI-LRS-slit.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb)  |
-| MIRI       | LRS Slitless   | 11.3       | 1.18.0 | [JWPipeNB-MIRI-LRS-slitless-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slitless-TSO/JWPipeNB-MIRI-LRS-slitless-TSO.ipynb)  |
-| MIRI       | MRS            | 11.3       | 1.18.0 | [JWPipeNB-MIRI-MRS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/MRS/JWPipeNB-MIRI-MRS.ipynb)  |
-| NIRCam     | Coronagraphy   | 11.3       | 1.18.0 | [JWPipeNB-nircam-coronagraphy.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/Coronagraphy/JWPipeNB-nircam-coronagraphy.ipynb)  |
-| NIRCam     | Imaging        | 11.3       | 1.18.0 | [JWPipeNB-nircam-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb)  |
-| NIRISS     | AMI            | 11.3       | 1.18.0 | [JWPipeNB-niriss-ami.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/AMI/JWPipeNB-niriss-ami.ipynb)  |
-| NIRISS     | Imaging        | 11.3       | 1.18.0 | [JWPipeNB-niriss-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/Imaging/JWPipeNB-niriss-imaging.ipynb)  |
-| NIRSpec    | BOTS           | 11.3       | 1.18.0 | [JWPipeNB-NIRSpec-BOTS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/BOTS/JWPipeNB-NIRSpec-BOTS.ipynb)  |
-| NIRSpec    | Fixed Slit     | 11.3       | 1.18.0 | [JWPipeNB-NIRSpec-FS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/FSlit/JWPipeNB-NIRSpec-FS.ipynb)  |
-| NIRSpec    | IFU            | 11.3       | 1.18.0 | [JWPipeNB-NIRSpec-IFU.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/IFU/JWPipeNB-NIRSpec-IFU.ipynb)  |
-| NIRSpec    | MOS            | 11.3       | 1.18.0 | [JWPipeNB-NIRSpec-MOS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/MOS/JWPipeNB-NIRSpec-MOS.ipynb)  |
+| MIRI       | Coronagraphy   | 11.3       | 1.18.1 | [JWPipeNB-MIRI-Coron.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb) |
+| MIRI       | Imaging        | 11.3       | 1.18.1 | [JWPipeNB-MIRI-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb) |
+| MIRI       | Imaging TSO    | 11.3       | 1.18.1 | [JWPipeNB-MIRI-imaging-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb)  |
+| MIRI       | LRS Slit       | 11.3       | 1.18.1 | [JWPipeNB-MIRI-LRS-slit.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb)  |
+| MIRI       | LRS Slitless   | 11.3       | 1.18.1 | [JWPipeNB-MIRI-LRS-slitless-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slitless-TSO/JWPipeNB-MIRI-LRS-slitless-TSO.ipynb)  |
+| MIRI       | MRS            | 11.3       | 1.18.1 | [JWPipeNB-MIRI-MRS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/MRS/JWPipeNB-MIRI-MRS.ipynb)  |
+| NIRCam     | Coronagraphy   | 11.3       | 1.18.1 | [JWPipeNB-nircam-coronagraphy.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/Coronagraphy/JWPipeNB-nircam-coronagraphy.ipynb)  |
+| NIRCam     | Imaging        | 11.3       | 1.18.1 | [JWPipeNB-nircam-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb)  |
+| NIRISS     | AMI            | 11.3       | 1.18.1 | [JWPipeNB-niriss-ami.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/AMI/JWPipeNB-niriss-ami.ipynb)  |
+| NIRISS     | Imaging        | 11.3       | 1.18.1 | [JWPipeNB-niriss-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/Imaging/JWPipeNB-niriss-imaging.ipynb)  |
+| NIRSpec    | BOTS           | 11.3       | 1.18.1 | [JWPipeNB-NIRSpec-BOTS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/BOTS/JWPipeNB-NIRSpec-BOTS.ipynb)  |
+| NIRSpec    | Fixed Slit     | 11.3       | 1.18.1 | [JWPipeNB-NIRSpec-FS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/FSlit/JWPipeNB-NIRSpec-FS.ipynb)  |
+| NIRSpec    | IFU            | 11.3       | 1.18.1 | [JWPipeNB-NIRSpec-IFU.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/IFU/JWPipeNB-NIRSpec-IFU.ipynb)  |
+| NIRSpec    | MOS            | 11.3       | 1.18.1 | [JWPipeNB-NIRSpec-MOS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/MOS/JWPipeNB-NIRSpec-MOS.ipynb)  |
 
 ## Reference Files
 

--- a/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb
+++ b/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "**Authors**: B. Nickson; MIRI branch<br>\n",
     "**Last Updated**: May 5, 2025<br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3)"
+    "**Pipeline Version**: 1.18.1 (Build 11.3)"
    ]
   },
   {

--- a/notebooks/MIRI/Coronagraphy/requirements.txt
+++ b/notebooks/MIRI/Coronagraphy/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter

--- a/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb
+++ b/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "**Authors**: Ian Wong; MIRI branch<br>\n",
     "**Last Updated**: May 5, 2025<br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3)"
+    "**Pipeline Version**: 1.18.1 (Build 11.3)"
    ]
   },
   {

--- a/notebooks/MIRI/Imaging-TSO/requirements.txt
+++ b/notebooks/MIRI/Imaging-TSO/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter

--- a/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb
+++ b/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "**Authors**: M. Cracraft<br>\n",
     "**Last Updated**: May 5, 2025<br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3)"
+    "**Pipeline Version**: 1.18.1 (Build 11.3)"
    ]
   },
   {
@@ -1467,7 +1467,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/Imaging/requirements.txt
+++ b/notebooks/MIRI/Imaging/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter

--- a/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb
+++ b/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "**Authors**: Ian Wong; MIRI branch<br>\n",
     "**Last Updated**: May 5, 2025<br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3)"
+    "**Pipeline Version**: 1.18.1 (Build 11.3)"
    ]
   },
   {

--- a/notebooks/MIRI/LRS-slit/requirements.txt
+++ b/notebooks/MIRI/LRS-slit/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter

--- a/notebooks/MIRI/LRS-slitless-TSO/JWPipeNB-MIRI-LRS-slitless-TSO.ipynb
+++ b/notebooks/MIRI/LRS-slitless-TSO/JWPipeNB-MIRI-LRS-slitless-TSO.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "**Authors**: Ian Wong; MIRI branch<br>\n",
     "**Last Updated**: May 5, 2025<br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3)"
+    "**Pipeline Version**: 1.18.1 (Build 11.3)"
    ]
   },
   {

--- a/notebooks/MIRI/LRS-slitless-TSO/requirements.txt
+++ b/notebooks/MIRI/LRS-slitless-TSO/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter

--- a/notebooks/MIRI/MRS/JWPipeNB-MIRI-MRS.ipynb
+++ b/notebooks/MIRI/MRS/JWPipeNB-MIRI-MRS.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "**Authors**: David Law, Kirsten Larson; MIRI branch<br>\n",
     "**Last Updated**: May 22, 2025<br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3)"
+    "**Pipeline Version**: 1.18.1 (Build 11.3)"
    ]
   },
   {

--- a/notebooks/MIRI/MRS/requirements.txt
+++ b/notebooks/MIRI/MRS/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter

--- a/notebooks/NIRCAM/Coronagraphy/JWPipeNB-nircam-coronagraphy.ipynb
+++ b/notebooks/NIRCAM/Coronagraphy/JWPipeNB-nircam-coronagraphy.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "**Authors**: B. Sunnquist, based on the NIRISS/NIRCam imaging notebooks by R. Diaz and B. Hilbert<br>\n",
     "**Last Updated**: May 5, 2025<br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3)"
+    "**Pipeline Version**: 1.18.1 (Build 11.3)"
    ]
   },
   {

--- a/notebooks/NIRCAM/Coronagraphy/requirements.txt
+++ b/notebooks/NIRCAM/Coronagraphy/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter

--- a/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb
+++ b/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "**Authors**: B. Hilbert, based on the NIRISS imaging notebook by R. Diaz<br>\n",
     "**Last Updated**: May 5, 2025<br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3)"
+    "**Pipeline Version**: 1.18.1 (Build 11.3)"
    ]
   },
   {

--- a/notebooks/NIRCAM/Imaging/requirements.txt
+++ b/notebooks/NIRCAM/Imaging/requirements.txt
@@ -1,4 +1,4 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter
 jdaviz==4.2.1

--- a/notebooks/NIRISS/AMI/JWPipeNB-niriss-ami.ipynb
+++ b/notebooks/NIRISS/AMI/JWPipeNB-niriss-ami.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "**Authors**: R. Cooper<br>\n",
     "**Last Updated**: April 15, 2025<br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3)"
+    "**Pipeline Version**: 1.18.1 (Build 11.3)"
    ]
   },
   {

--- a/notebooks/NIRISS/AMI/requirements.txt
+++ b/notebooks/NIRISS/AMI/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter

--- a/notebooks/NIRISS/Imaging/JWPipeNB-niriss-imaging.ipynb
+++ b/notebooks/NIRISS/Imaging/JWPipeNB-niriss-imaging.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "**Authors**: S. LaMassa, R. Diaz<br>\n",
     "**Last Updated**: May 5, 2025<br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3)"
+    "**Pipeline Version**: 1.18.1 (Build 11.3)"
    ]
   },
   {

--- a/notebooks/NIRISS/Imaging/requirements.txt
+++ b/notebooks/NIRISS/Imaging/requirements.txt
@@ -1,4 +1,4 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter
 jdaviz

--- a/notebooks/NIRSPEC/BOTS/JWPipeNB-NIRSpec-BOTS.ipynb
+++ b/notebooks/NIRSPEC/BOTS/JWPipeNB-NIRSpec-BOTS.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "**Authors**: Nikolay Nikolov (AURA Associate Scientist, nnikolov@stsci.edu); Kayli Glidic (kglidic@stsci.edu); NIRSpec branch</br>\n",
     "**Last Updated**: April 18, 2025</br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3, Context jwst_1364.pmap)\n",
+    "**Pipeline Version**: 1.18.1 (Build 11.3, Context jwst_1364.pmap)\n",
     "\n",
     "**Purpose**:<br>\n",
     "End-to-end calibration with the James Webb Space Telescope (JWST) pipeline is divided into three main processing stages. This notebook provides a framework for processing generic Near-Infrared Spectrograph (NIRSpec) Bright Object Time-Series (BOTS) data through [stages 1-3 of the JWST pipeline](https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline/stages-of-jwst-data-processing#gsc.tab=0), including how to use associations for multi-exposure observations and how to interact and work with JWST datamodels. In most cases, editing cells outside the [Configuration](#1.-Configuration) section is unnecessary unless the standard pipeline processing options or plot parameters need to be modified.\n",

--- a/notebooks/NIRSPEC/BOTS/requirements.txt
+++ b/notebooks/NIRSPEC/BOTS/requirements.txt
@@ -1,4 +1,4 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter
 matplotlib>=3.9.2

--- a/notebooks/NIRSPEC/FSlit/JWPipeNB-NIRSpec-FS.ipynb
+++ b/notebooks/NIRSPEC/FSlit/JWPipeNB-NIRSpec-FS.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "**Authors**: Elena Manjavacas (emanjavacas@stsci.edu), building on the work of Peter Zeidler (zeidler@stsci.edu), Kayli Glidic (kglidic@stsci.edu), and James Muzerolle (muzerol@stsci.edu); NIRSpec branch </br>\n",
     "**Last Updated**: April 16, 2025 </br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3, Context jwst_1364.pmap)\n",
+    "**Pipeline Version**: 1.18.1 (Build 11.3, Context jwst_1364.pmap)\n",
     "\n",
     "**Purpose**:<br>\n",
     "This notebook provides a framework for processing generic Near-Infrared Spectrograph (NIRSpec) fixed slit (FS) data through the three stages of the JWST pipeline. It includes how to use associations for multi-exposure observations and how to interact and work with JWST datamodels. Data is assumed to be organized into two folders: science and background, as specified in the paths set up below. In most cases, editing cells outside the [Configuration](#1.-Configuration) section is unnecessary unless the standard pipeline processing options or plot parameters need to be modified.\n",

--- a/notebooks/NIRSPEC/FSlit/requirements.txt
+++ b/notebooks/NIRSPEC/FSlit/requirements.txt
@@ -1,4 +1,4 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter
 jdaviz>=4.2.1

--- a/notebooks/NIRSPEC/IFU/JWPipeNB-NIRSpec-IFU.ipynb
+++ b/notebooks/NIRSPEC/IFU/JWPipeNB-NIRSpec-IFU.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "**Authors**: Kayli Glidic (kglidic@stsci.edu), Maria Pena-Guerrero (pena@stsci.edu), Leonardo Ubeda (lubeda@stsci.edu); NIRSpec branch<br>\n",
     "**Last Updated**: April 16, 2025 </br>\n",
-    "**Pipeline Version**: 1.18.0 (Build 11.3, Context jwst_1364.pmap)\n",
+    "**Pipeline Version**: 1.18.1 (Build 11.3, Context jwst_1364.pmap)\n",
     "\n",
     "**Purpose**:<br>\n",
     "End-to-end calibration with the James Webb Space Telescope (JWST) pipeline is divided into three main processing stages. This notebook provides a framework for processing generic Near-Infrared Spectrograph (NIRSpec) integral field unit (IFU) data through [stages 1-3 of the JWST pipeline](https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline/stages-of-jwst-data-processing#gsc.tab=0), including how to use associations for multi-exposure observations and how to interact and work with JWST datamodels. Data is assumed to be organized into two folders: science and background, as specified in the paths set up below. In most cases, editing cells outside the [Configuration](#1.-Configuration) section is unnecessary unless the standard pipeline processing options or plot parameters need to be modified.\n",

--- a/notebooks/NIRSPEC/IFU/requirements.txt
+++ b/notebooks/NIRSPEC/IFU/requirements.txt
@@ -1,4 +1,4 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter
 jdaviz>=4.2.1

--- a/notebooks/NIRSPEC/MOS/requirements.txt
+++ b/notebooks/NIRSPEC/MOS/requirements.txt
@@ -1,4 +1,4 @@
-jwst==1.18.0
+jwst==1.18.1
 astroquery>=0.4.8
 jupyter
 jdaviz>=4.2.1


### PR DESCRIPTION
JWST build 11.3 has recently been updated from jwst software version 1.18.0 to 1.18.1.  For external users this update is relevant only for some rare cases of WFSS, which does not currently have a pipeline notebook.  All notebooks are being updated to jwst 1.18.1 for consistency with the version numbers that will be found in MAST data products, but this change should thus have no effect otherwise.