### PR TITLE
Update jdaviz pin for NIRCam imaging

### DIFF
--- a/notebooks/NIRCAM/Imaging/requirements.txt
+++ b/notebooks/NIRCAM/Imaging/requirements.txt
@@ -1,4 +1,4 @@
 jwst==1.18.1
 astroquery>=0.4.8
 jupyter
-jdaviz==4.2.1
+jdaviz==4.2.3


### PR DESCRIPTION
This PR updates the JDAviz pin for NIRCam imaging to address a crash caused by a recent specutils update renaming the Spectrum1D object.