### PR TITLE
Update NIRISS code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,8 @@
 /notebooks/MIRI/LRS-slit/   @ianyuwong  @skendrew  @drlaw1558
 /notebooks/MIRI/LRS-slitless-TSO/   @ianyuwong  @skendrew  @drlaw1558
 /notebooks/MIRI/MRS/   @kilarson  @skendrew  @drlaw1558
-/notebooks/NIRISS/AMI/   @spacetelescope/niriss  @drlaw1558
-/notebooks/NIRISS/Imaging/   @spacetelescope/niriss  @drlaw1558
+/notebooks/NIRISS/AMI/   @rcooper295 @Rplesha  @drlaw1558
+/notebooks/NIRISS/Imaging/   @goudfroo @Rplesha  @drlaw1558
 /notebooks/NIRSPEC/BOTS/   @hayescr  @kglidic  @drlaw1558
 /notebooks/NIRSPEC/FSlit/   @hayescr  @kglidic  @drlaw1558
 /notebooks/NIRSPEC/IFU/   @hayescr  @kglidic  @drlaw1558


### PR DESCRIPTION
Tagging @sosey for review; this PR changes the NIRISS code owners to specific people identified by the NIRISS team instead of the entire group.