### PR TITLE
Update to 12.1 and fix typo in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following table summarizes the notebooks currently available and the JWST [p
 
 | Instrument | Observing Mode | JWST Build | ``jwst`` version | Notebook                                         |
 |------------|----------------|------------|--------------------------|-----------------------------------------------|
-| MIRI       | Coronagraphy   | 12.0       | 1.19.1 | [JWPipeNB-MIRI-Coron.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb) |
+| MIRI       | Coronagraphy   | 12.1       | 1.20.2 | [JWPipeNB-MIRI-Coron.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb) |
 | MIRI       | Imaging        | 12.0       | 1.19.1 | [JWPipeNB-MIRI-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb) |
 | MIRI       | Imaging TSO    | 12.0       | 1.19.1 | [JWPipeNB-MIRI-imaging-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb)  |
 | MIRI       | LRS Slit       | 12.0       | 1.19.1 | [JWPipeNB-MIRI-LRS-slit.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb)  |

--- a/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb
+++ b/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb
@@ -14,7 +14,7 @@
    "metadata": {},
    "source": [
     "<a id=\"title_ID\"></a>\n",
-    "# MIRI Conagraphy Pipeline Notebook #"
+    "# MIRI Coronagraphy Pipeline Notebook #"
    ]
   },
   {
@@ -23,8 +23,8 @@
    "metadata": {},
    "source": [
     "**Authors**: B. Nickson; MIRI branch<br>\n",
-    "**Last Updated**: July 16, 2025<br>\n",
-    "**Pipeline Version**: 1.19.1 (Build 12.0)"
+    "**Last Updated**: November 10, 2025<br>\n",
+    "**Pipeline Version**: 1.20.2 (Build 12.1)"
    ]
   },
   {
@@ -61,7 +61,8 @@
     "**Recent Changes**:<br>\n",
     "Jan 28, 2025: Migrate from the `Coronagraphy_ExambleNB` notebook, update to Build 11.2 (jwst 1.17.1).<br>\n",
     "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)<br>\n",
-    "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)"
+    "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)<br>\n",
+    "November 10, 2025: Updated to jwst 1.20.2 (no significant changes)"
    ]
   },
   {

--- a/notebooks/MIRI/Coronagraphy/requirements.txt
+++ b/notebooks/MIRI/Coronagraphy/requirements.txt
@@ -1,3 +1,3 @@
-jwst==1.19.1
+jwst==1.20.2
 astroquery>=0.4.8
 jupyter


### PR DESCRIPTION
This PR fixed a typo in the title of the MIRI Coronagraphy notebook, and at the same time updates it to jwst pipeline build 12.1.  The actual functionality should be unchanged, but tagging @brynickson to review in case there were any other changes that you wanted to make.