### PR TITLE
 add google analytics common id

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,6 +46,7 @@ repository:
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository
 html:
-  google_analytics_id:
   use_issues_button: true
   use_repository_button: true
+  analytics:
+    google_analytics_id: G-2XDY0S4S5Q


### PR DESCRIPTION
This PR adds a google analytics common id. Working on testing repo seperation on the google end of things. 