### PR TITLE
Update non-nirspec notebooks to jwst 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,23 +20,23 @@ The following table summarizes the notebooks currently available and the JWST [p
 
 | Instrument | Observing Mode | JWST Build | ``jwst`` version | Notebook                                         |
 |------------|----------------|------------|--------------------------|-----------------------------------------------|
-| MIRI       | Coronagraphy   | 12.3       | 2.0.0 | [JWPipeNB-MIRI-Coron.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb) |
-| MIRI       | Imaging        | 12.3       | 2.0.0 | [JWPipeNB-MIRI-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb) |
-| MIRI       | Imaging TSO    | 12.3       | 2.0.0 | [JWPipeNB-MIRI-imaging-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb)  |
-| MIRI       | LRS Slit       | 12.3       | 2.0.0 | [JWPipeNB-MIRI-LRS-slit.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb)  |
-| MIRI       | LRS Slitless   | 12.3       | 2.0.0 | [JWPipeNB-MIRI-LRS-slitless-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slitless-TSO/JWPipeNB-MIRI-LRS-slitless-TSO.ipynb)  |
-| MIRI       | MRS            | 12.3       | 2.0.0 | [JWPipeNB-MIRI-MRS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/MRS/JWPipeNB-MIRI-MRS.ipynb)  |
-| NIRCam     | Coronagraphy   | 12.3       | 2.0.0 | [JWPipeNB-nircam-coronagraphy.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/Coronagraphy/JWPipeNB-nircam-coronagraphy.ipynb)  |
-| NIRCam     | Imaging        | 12.3       | 2.0.0 | [JWPipeNB-nircam-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb)  |
-| NIRCam     | LW Grism TSO   | 12.3       | 2.0.0 | [JWPipeNB-NIRCam-LWGTS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/LW_Grism_Time_Series/JWPipeNB-NIRCam-LWGTS.ipynb)  |
-| NIRISS     | AMI            | 12.3       | 2.0.0 | [JWPipeNB-niriss-ami.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/AMI/JWPipeNB-niriss-ami.ipynb)  |
-| NIRISS     | Imaging        | 12.3       | 2.0.0 | [JWPipeNB-niriss-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/Imaging/JWPipeNB-niriss-imaging.ipynb)  |
-| NIRISS     | SOSS           | 12.3       | 2.0.0 | [JWPipeNB-niriss-soss.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/SOSS/JWPipeNB-niriss-soss.ipynb)  |
-| NIRISS     | WFSS           | 12.3       | 2.0.0 | [JWPipeNB-niriss-wfss.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/WFSS/JWPipeNB-niriss-wfss.ipynb)  |
-| NIRSpec    | BOTS           | 12.3       | 2.0.0 | [JWPipeNB-NIRSpec-BOTS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/BOTS/JWPipeNB-NIRSpec-BOTS.ipynb)  |
-| NIRSpec    | Fixed Slit     | 12.3       | 2.0.0 | [JWPipeNB-NIRSpec-FS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/FSlit/JWPipeNB-NIRSpec-FS.ipynb)  |
-| NIRSpec    | IFU            | 12.3       | 2.0.0 | [JWPipeNB-NIRSpec-IFU.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/IFU/JWPipeNB-NIRSpec-IFU.ipynb)  |
-| NIRSpec    | MOS            | 12.3       | 2.0.0 | [JWPipeNB-NIRSpec-MOS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/MOS/JWPipeNB-NIRSpec-MOS.ipynb)  |
+| MIRI       | Coronagraphy   | 13.0       | 3.0.0 | [JWPipeNB-MIRI-Coron.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb) |
+| MIRI       | Imaging        | 13.0       | 3.0.0 | [JWPipeNB-MIRI-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb) |
+| MIRI       | Imaging TSO    | 13.0       | 3.0.0 | [JWPipeNB-MIRI-imaging-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb)  |
+| MIRI       | LRS Slit       | 13.0       | 3.0.0 | [JWPipeNB-MIRI-LRS-slit.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb)  |
+| MIRI       | LRS Slitless   | 13.0       | 3.0.0 | [JWPipeNB-MIRI-LRS-slitless-TSO.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/LRS-slitless-TSO/JWPipeNB-MIRI-LRS-slitless-TSO.ipynb)  |
+| MIRI       | MRS            | 13.0       | 3.0.0 | [JWPipeNB-MIRI-MRS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/MIRI/MRS/JWPipeNB-MIRI-MRS.ipynb)  |
+| NIRCam     | Coronagraphy   | 13.0       | 3.0.0 | [JWPipeNB-nircam-coronagraphy.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/Coronagraphy/JWPipeNB-nircam-coronagraphy.ipynb)  |
+| NIRCam     | Imaging        | 13.0       | 3.0.0 | [JWPipeNB-nircam-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb)  |
+| NIRCam     | LW Grism TSO   | 13.0       | 3.0.0 | [JWPipeNB-NIRCam-LWGTS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRCAM/LW_Grism_Time_Series/JWPipeNB-NIRCam-LWGTS.ipynb)  |
+| NIRISS     | AMI            | 13.0       | 3.0.0 | [JWPipeNB-niriss-ami.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/AMI/JWPipeNB-niriss-ami.ipynb)  |
+| NIRISS     | Imaging        | 13.0       | 3.0.0 | [JWPipeNB-niriss-imaging.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/Imaging/JWPipeNB-niriss-imaging.ipynb)  |
+| NIRISS     | SOSS           | 13.0       | 3.0.0 | [JWPipeNB-niriss-soss.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/SOSS/JWPipeNB-niriss-soss.ipynb)  |
+| NIRISS     | WFSS           | 13.0       | 3.0.0 | [JWPipeNB-niriss-wfss.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRISS/WFSS/JWPipeNB-niriss-wfss.ipynb)  |
+| NIRSpec    | BOTS           | 13.0       | 3.0.0 | [JWPipeNB-NIRSpec-BOTS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/BOTS/JWPipeNB-NIRSpec-BOTS.ipynb)  |
+| NIRSpec    | Fixed Slit     | 13.0       | 3.0.0 | [JWPipeNB-NIRSpec-FS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/FSlit/JWPipeNB-NIRSpec-FS.ipynb)  |
+| NIRSpec    | IFU            | 13.0       | 3.0.0 | [JWPipeNB-NIRSpec-IFU.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/IFU/JWPipeNB-NIRSpec-IFU.ipynb)  |
+| NIRSpec    | MOS            | 13.0       | 3.0.0 | [JWPipeNB-NIRSpec-MOS.ipynb](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/MOS/JWPipeNB-NIRSpec-MOS.ipynb)  |
 
 ## Reference Files
 

--- a/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb
+++ b/notebooks/MIRI/Coronagraphy/JWPipeNB-MIRI-Coron.ipynb
@@ -23,8 +23,8 @@
    "metadata": {},
    "source": [
     "**Authors**: B. Nickson; MIRI branch, A. L. Carter; NIRISS branch<br>\n",
-    "**Last Updated**: April 17, 2026<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -64,7 +64,8 @@
     "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)<br>\n",
     "November 10, 2025: Updated to jwst 1.20.2 (no significant changes)<br>\n",
     "March 27, 2026: Updated to demonstrate PSF library subtraction<br>\n",
-    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {
@@ -2239,7 +2240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/Coronagraphy/requirements.txt
+++ b/notebooks/MIRI/Coronagraphy/requirements.txt
@@ -1,3 +1,3 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.8
 jupyter

--- a/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb
+++ b/notebooks/MIRI/Imaging-TSO/JWPipeNB-MIRI-imaging-TSO.ipynb
@@ -16,8 +16,8 @@
     "# MIRI Imaging TSO Pipeline Notebook\n",
     "\n",
     "**Authors**: Ian Wong; MIRI branch<br>\n",
-    "**Last Updated**: April 17, 2026<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -56,7 +56,8 @@
     "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)<br>\n",
     "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)<br>\n",
     "December 10, 2025: Updated to jwst 1.20.2 (no significant changes)<br>\n",
-    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {
@@ -1017,7 +1018,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/Imaging-TSO/requirements.txt
+++ b/notebooks/MIRI/Imaging-TSO/requirements.txt
@@ -1,3 +1,3 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.8
 jupyter

--- a/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb
+++ b/notebooks/MIRI/Imaging/JWPipeNB-MIRI-imaging.ipynb
@@ -16,8 +16,8 @@
     "# MIRI Imaging Pipeline Notebook\n",
     "\n",
     "**Authors**: M. Cracraft<br>\n",
-    "**Last Updated**: April 17, 2026<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -57,7 +57,8 @@
     "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)<br>\n",
     "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)<br>\n",
     "December 10, 2025: Updated to jwst 1.20.2 (no significant changes)<br>\n",
-    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {
@@ -1462,7 +1463,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/Imaging/requirements.txt
+++ b/notebooks/MIRI/Imaging/requirements.txt
@@ -1,3 +1,3 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.8
 jupyter

--- a/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb
+++ b/notebooks/MIRI/LRS-slit/JWPipeNB-MIRI-LRS-slit.ipynb
@@ -23,8 +23,8 @@
    "metadata": {},
    "source": [
     "**Authors**: Ian Wong; MIRI branch<br>\n",
-    "**Last Updated**: April 17, 2026<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -60,7 +60,8 @@
     "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)<br>\n",
     "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)<br>\n",
     "Nov 20, 2025: Updated to jwst 1.20.2, added option to use optimal extraction<br>\n",
-    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {
@@ -1123,7 +1124,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/LRS-slit/requirements.txt
+++ b/notebooks/MIRI/LRS-slit/requirements.txt
@@ -1,3 +1,3 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.8
 jupyter

--- a/notebooks/MIRI/LRS-slitless-TSO/JWPipeNB-MIRI-LRS-slitless-TSO.ipynb
+++ b/notebooks/MIRI/LRS-slitless-TSO/JWPipeNB-MIRI-LRS-slitless-TSO.ipynb
@@ -23,8 +23,8 @@
    "metadata": {},
    "source": [
     "**Authors**: Ian Wong; MIRI branch<br>\n",
-    "**Last Updated**: April 17, 2026<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -62,7 +62,8 @@
     "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)<br>\n",
     "July 16, 2025: Updated to jwst 1.19.1 (update plotting to work with new spectral data table format)<br>\n",
     "December 10, 2025: Updated to jwst 1.20.2 (no significant updates)<br>\n",
-    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {
@@ -1212,7 +1213,7 @@
     "    for val in colors:\n",
     "        flux[val] = []\n",
     "        \n",
-    "    for i, exten in enumerate(range(2, len(hdul)-1)):\n",
+    "    for i, exten in enumerate(range(2, len(hdul)-2)):\n",
     "        tmp_spec = hdul[exten].data\n",
     "        for ii in range(len(wave_idxs)):\n",
     "            flux[colors[ii]].extend(tmp_spec['FLUX'][:, wave_idxs[ii]])\n",
@@ -1278,7 +1279,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/LRS-slitless-TSO/requirements.txt
+++ b/notebooks/MIRI/LRS-slitless-TSO/requirements.txt
@@ -1,3 +1,3 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.8
 jupyter

--- a/notebooks/MIRI/MRS/JWPipeNB-MIRI-MRS.ipynb
+++ b/notebooks/MIRI/MRS/JWPipeNB-MIRI-MRS.ipynb
@@ -23,8 +23,8 @@
    "metadata": {},
    "source": [
     "**Authors**: David Law, Kirsten Larson; MIRI branch<br>\n",
-    "**Last Updated**: April 17, 2026<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -70,7 +70,8 @@
     "July 16 2025: No significant updates.<br>\n",
     "Sep 03 2025: Minor update to remove mrs_imatch step<br>\n",
     "December 10 2025: No significant updates.<br>\n",
-    "April 17, 2026: Updated to jwst 2.0.0; add Adaptive Trace Model option to spec3."
+    "April 17, 2026: Updated to jwst 2.0.0; add Adaptive Trace Model option to spec3.<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {
@@ -1516,7 +1517,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/MRS/requirements.txt
+++ b/notebooks/MIRI/MRS/requirements.txt
@@ -1,3 +1,3 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.8
 jupyter

--- a/notebooks/NIRCAM/Coronagraphy/JWPipeNB-nircam-coronagraphy.ipynb
+++ b/notebooks/NIRCAM/Coronagraphy/JWPipeNB-nircam-coronagraphy.ipynb
@@ -16,8 +16,8 @@
     "#  NIRCam Coronagraphy Pipeline Notebook\n",
     "\n",
     "**Authors**: B. Sunnquist, A.L. Carter, based on the NIRISS/NIRCam imaging notebooks by R. Diaz and B. Hilbert<br>\n",
-    "**Last Updated**: April 17, 2026<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -58,7 +58,8 @@
     "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)<br>\n",
     "December 10, 2025: Updated to jwst 1.20.2 (no significant changes)<br>\n",
     "March 27, 2026: Updated to demonstrate PSF library subtraction<br>\n",
-    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {
@@ -1682,7 +1683,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRCAM/Coronagraphy/requirements.txt
+++ b/notebooks/NIRCAM/Coronagraphy/requirements.txt
@@ -1,3 +1,3 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.8
 jupyter

--- a/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb
+++ b/notebooks/NIRCAM/Imaging/JWPipeNB-nircam-imaging.ipynb
@@ -16,8 +16,8 @@
     "#  NIRCam Imaging Pipeline Notebook\n",
     "\n",
     "**Authors**: B. Hilbert, based on the NIRISS imaging notebook by R. Diaz<br>\n",
-    "**Last Updated**: April 17, 2026<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -68,7 +68,8 @@
     "May 5, 2025: Updated to jwst 1.18.0 (no significant changes)<br>\n",
     "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)<br>\n",
     "Sept 30, 2025: Updated to jwst 1.20.0, update to work with JDAViz 4.4.1<br>\n",
-    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {
@@ -1985,7 +1986,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRCAM/Imaging/requirements.txt
+++ b/notebooks/NIRCAM/Imaging/requirements.txt
@@ -1,4 +1,4 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.11
 jupyter
 jdaviz==4.4.1

--- a/notebooks/NIRCAM/LW_Grism_Time_Series/JWPipeNB-NIRCam-LWGTS.ipynb
+++ b/notebooks/NIRCAM/LW_Grism_Time_Series/JWPipeNB-NIRCam-LWGTS.ipynb
@@ -19,9 +19,8 @@
     "\n",
     "**Authors**: Brian Brooks, Bryan Hilbert, Achrène Dyrek  based on the work by Nikolay Nikolov\n",
     "<br>\n",
-    "**Last Update**: April 15, 2026\n",
-    "<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -53,7 +52,8 @@
     "**Recent Changes**:<br>\n",
     "December 10, 2025: Updated notebook to be compatible with JWST pipeline version 1.20.2<br>\n",
     "March 10, 2026: Updated to fix broken links and to be compatible with segemented uncal file changes<br>\n",
-    "April 15, 2026: Updated to be compatible with JWST pipeline version 2.0.0"
+    "April 15, 2026: Updated to be compatible with JWST pipeline version 2.0.0<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {

--- a/notebooks/NIRCAM/LW_Grism_Time_Series/requirements.txt
+++ b/notebooks/NIRCAM/LW_Grism_Time_Series/requirements.txt
@@ -1,4 +1,4 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.11
 ipython
 jupyter

--- a/notebooks/NIRISS/AMI/JWPipeNB-niriss-ami.ipynb
+++ b/notebooks/NIRISS/AMI/JWPipeNB-niriss-ami.ipynb
@@ -16,8 +16,8 @@
     "##### NIRISS AMI Pipeline Notebook\n",
     "\n",
     "**Authors**: R. Cooper<br>\n",
-    "**Last Updated**: April 17, 2026<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -73,7 +73,8 @@
     "March 31, 2025: original notebook released<br>\n",
     "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)<br>\n",
     "December 10, 2025: Updated to jwst 1.20.2 (no significant changes)<br>\n",
-    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {
@@ -1635,7 +1636,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRISS/AMI/requirements.txt
+++ b/notebooks/NIRISS/AMI/requirements.txt
@@ -1,3 +1,3 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.8
 jupyter

--- a/notebooks/NIRISS/Imaging/JWPipeNB-niriss-imaging.ipynb
+++ b/notebooks/NIRISS/Imaging/JWPipeNB-niriss-imaging.ipynb
@@ -16,8 +16,8 @@
     "# NIRISS Imaging Pipeline Notebook\n",
     "\n",
     "**Authors**: S. LaMassa, R. Diaz<br>\n",
-    "**Last Updated**: April 17, 2026<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -70,7 +70,8 @@
     "May 5, 2025: Updated to jwst 1.18.0 (no significant changes).<br>\n",
     "July 16, 2025: Updated to jwst 1.19.1 (no significant changes)<br>\n",
     "December 10 2025: Updated to jwst 1.20.2 (no significant changes)<br>\n",
-    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {
@@ -1362,7 +1363,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRISS/Imaging/requirements.txt
+++ b/notebooks/NIRISS/Imaging/requirements.txt
@@ -1,4 +1,4 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.8
 jupyter
 jdaviz

--- a/notebooks/NIRISS/SOSS/JWPipeNB-niriss-soss.ipynb
+++ b/notebooks/NIRISS/SOSS/JWPipeNB-niriss-soss.ipynb
@@ -16,8 +16,8 @@
     "# NIRISS SOSS Pipeline Notebook\n",
     "\n",
     "**Authors**: R. Cooper, A. Carter, N. Espinoza, T. Baines<br>\n",
-    "**Last Updated**: April 17, 2026<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -75,7 +75,8 @@
     "\n",
     "**Recent Changes**:<br>\n",
     "November 07, 2025: original notebook released<br>\n",
-    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {
@@ -2014,7 +2015,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRISS/SOSS/requirements.txt
+++ b/notebooks/NIRISS/SOSS/requirements.txt
@@ -1,4 +1,4 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.10
 batman-package
 jupyter

--- a/notebooks/NIRISS/WFSS/JWPipeNB-niriss-wfss.ipynb
+++ b/notebooks/NIRISS/WFSS/JWPipeNB-niriss-wfss.ipynb
@@ -16,8 +16,8 @@
     "# NIRISS Wide Field Slitless Spectroscopy (WFSS) Pipeline Notebook\n",
     "\n",
     "**Authors**: R. Plesha<br>\n",
-    "**Last Updated**: April 17, 2026<br>\n",
-    "**Pipeline Version**: 2.0.0 (Build 12.3)"
+    "**Last Updated**: July 27, 2026<br>\n",
+    "**Pipeline Version**: 3.0.0 (Build 13.0)"
    ]
   },
   {
@@ -43,7 +43,8 @@
     "**Recent Changes**:<br>\n",
     "September 10, 2025: original notebook released<br>\n",
     "December 10, 2025: Updated to jwst 1.20.2 (no significant changes)<br>\n",
-    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)"
+    "April 17, 2026: Updated to jwst 2.0.0 (no significant changes)<br>\n",
+    "July 27, 2026: Updated to jwst 3.0.0 (no significant changes)"
    ]
   },
   {
@@ -2431,7 +2432,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRISS/WFSS/requirements.txt
+++ b/notebooks/NIRISS/WFSS/requirements.txt
@@ -1,4 +1,4 @@
-jwst==2.0.0
+jwst==3.0.0
 astroquery>=0.4.10
 jupyter
 matplotlib>=3.8.2


### PR DESCRIPTION
This PR updates all non-NIRSpec notebooks to use jwst 3.0.0 (build 13.0).  Since updates are only to the requirements files and the version stamp at the top of each notebook I'm not planning to wait for signoff from each individual notebook owner.

The one exception is MIRI LRS slitless TSO, in which the introduction of a new 'HDRTAB' extension in the x1dints files required a change to plot routines from running over extensions range(2, len(hdul)-1) to range(2, len(hdul)-2)  @ianyuwong FYI

NIRSpec notebooks already taken care of via https://github.com/spacetelescope/jwst-pipeline-notebooks/pull/104
